### PR TITLE
VC++ compatibility for isnan

### DIFF
--- a/octomap/src/compare_octrees.cpp
+++ b/octomap/src/compare_octrees.cpp
@@ -39,7 +39,9 @@
 #include <list>
 #include <cmath>
 
+#ifdef _MSC_VER
 #define isnan(x) _isnan(x)  //for VC++
+#endif
 
 using std::cout;
 using std::endl;


### PR DESCRIPTION
removes error in Visual C++: error C2039: '_isnan' : is not a member of 'std'
