### PR TITLE
Fix issues when building on systems with libc++ (OS X 10.9 Mavericks)

### DIFF
--- a/octomap/include/octomap/OcTreeKey.h
+++ b/octomap/include/octomap/OcTreeKey.h
@@ -34,14 +34,24 @@
 #ifndef OCTOMAP_OCTREE_KEY_H
 #define OCTOMAP_OCTREE_KEY_H
 
+/* According to c++ standard including this header has no practical effect
+ * but it can be used to determine the c++ standard library implementation.
+ */
+#include <ciso646>
 
 #include <assert.h>
-#ifdef __GNUC__
+
+/* Libc++ does not implement the TR1 namespace, all c++11 related functionality
+ * is instead implemented in the std namespace.
+ */
+#if defined(__GNUC__) && ! defined(_LIBCPP_VERSION)
   #include <tr1/unordered_set>
   #include <tr1/unordered_map>
+  #define UNORDERED_NAMESPACE std::tr1
 #else
   #include <unordered_set>
   #include <unordered_map>
+  #define UNORDERED_NAMESPACE std
 #endif
 
 namespace octomap {
@@ -95,14 +105,14 @@ namespace octomap {
    * @note you need to use boost::unordered_set instead if your compiler does not
    * yet support tr1!
    */
-  typedef std::tr1::unordered_set<OcTreeKey, OcTreeKey::KeyHash> KeySet;
+  typedef UNORDERED_NAMESPACE::unordered_set<OcTreeKey, OcTreeKey::KeyHash> KeySet;
 
   /**
    * Data structrure to efficiently track changed nodes as a combination of
    * OcTreeKeys and a bool flag (to denote newly created nodes)
    *
    */
-  typedef std::tr1::unordered_map<OcTreeKey, bool, OcTreeKey::KeyHash> KeyBoolMap;
+  typedef UNORDERED_NAMESPACE::unordered_map<OcTreeKey, bool, OcTreeKey::KeyHash> KeyBoolMap;
 
 
   class KeyRay {

--- a/octomap/src/Pointcloud.cpp
+++ b/octomap/src/Pointcloud.cpp
@@ -31,7 +31,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef _MSC_VER
+/* According to c++ standard including this header has no practical effect
+ * but it can be used to determine the c++ standard library implementation.
+ */ 
+#include <ciso646>
+
+#if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
   #include <algorithm>
 #else
   #include <ext/algorithm>
@@ -199,8 +204,8 @@ namespace octomap {
 
   void Pointcloud::subSampleRandom(unsigned int num_samples, Pointcloud& sample_cloud) {
     point3d_collection samples;
-    // visual studio does not support random_sample_n
-  #ifdef _MSC_VER
+    // visual studio does not support random_sample_n and neither does libc++
+  #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
     samples.reserve(this->size());
     samples.insert(samples.end(), this->begin(), this->end());
     std::random_shuffle(samples.begin(), samples.end());

--- a/octomap/src/testing/test_iterators.cpp
+++ b/octomap/src/testing/test_iterators.cpp
@@ -350,7 +350,7 @@ int main(int argc, char** argv) {
   EXPECT_TRUE(tree->coordToKeyChecked(bbxMin, bbxMinKey));
   EXPECT_TRUE(tree->coordToKeyChecked(bbxMax, bbxMaxKey));
 
-  typedef std::tr1::unordered_map<OcTreeKey, double, OcTreeKey::KeyHash> KeyVolumeMap;
+  typedef UNORDERED_NAMESPACE::unordered_map<OcTreeKey, double, OcTreeKey::KeyHash> KeyVolumeMap;
 
   KeyVolumeMap bbxVoxels;
 


### PR DESCRIPTION
These changes enable building on systems that use libc++ as the c++ standard library implementation, currently the most prominent being Mac OS X 10.9 Mavericks. Basically there are some trivial namespace issues that can be easily adapted. This should fix #52 and address the some of the issues discussed here: http://answers.ros.org/question/94771/building-octomap-orocos_kdl-and-other-packages-on-osx-109-solution/
