### PR TITLE
add missing includes

### DIFF
--- a/octovis/src/SelectionBox.cpp
+++ b/octovis/src/SelectionBox.cpp
@@ -26,6 +26,7 @@
 // workaround for Windows
 #define NOMINMAX
 #include <octovis/SelectionBox.h>
+#include <QGLViewer/manipulatedFrame.h>
 
 namespace octomap{
 

--- a/octovis/src/ViewerWidget.cpp
+++ b/octovis/src/ViewerWidget.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <octovis/ViewerWidget.h>
+#include <QGLViewer/manipulatedCameraFrame.h>
 
 #ifndef M_PI_2
 #define M_PI_2 1.5707963267948966192E0


### PR DESCRIPTION
This is required on QGLViewer > 2.5 as the other headers only have forward
references on ManipulatedFrame and ManipulatedCameraFrame. Since the added
headers exist on older versions of QGLViewer, it should not be an issue on older
versions of the library.
