### PR TITLE
Fixed octovis include

### DIFF
--- a/octovis/src/SelectionBox.cpp
+++ b/octovis/src/SelectionBox.cpp
@@ -26,7 +26,7 @@
 // workaround for Windows
 #define NOMINMAX
 #include <octovis/SelectionBox.h>
-#include <QGLViewer/manipulatedFrame.h>
+#include <manipulatedFrame.h>
 
 namespace octomap{
 

--- a/octovis/src/ViewerWidget.cpp
+++ b/octovis/src/ViewerWidget.cpp
@@ -24,7 +24,7 @@
  */
 
 #include <octovis/ViewerWidget.h>
-#include <QGLViewer/manipulatedCameraFrame.h>
+#include <manipulatedCameraFrame.h>
 
 #ifndef M_PI_2
 #define M_PI_2 1.5707963267948966192E0


### PR DESCRIPTION
The CMake procedure is including <.../octovis/src/extern/QGLViewer> and the includes were <QGLViewer/file.h> leading to a no such file error.
