### PR TITLE
Adding CMAKE option to choose if octovis&dynamicEDT3D should be built (BUILD_OCTOVIS_SUBPROJECT)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,15 @@ PROJECT( octomap-distribution )
 ENABLE_TESTING()  # enable CTest environment of subprojects
 
 option(BUILD_OCTOVIS_SUBPROJECT "Build targets from subproject octovis" ON)
+option(BUILD_DYNAMICETD3D_SUBPROJECT  "Build targets from subproject dynamicEDT3D" ON)
 
 ADD_SUBDIRECTORY( octomap )
+
 if(BUILD_OCTOVIS_SUBPROJECT)
 	ADD_SUBDIRECTORY( octovis )
+endif()		
+
+if(BUILD_DYNAMICETD3D_SUBPROJECT)	
 	ADD_SUBDIRECTORY( dynamicEDT3D )
 endif()		
 


### PR DESCRIPTION
As suggested in issue #65 (https://github.com/OctoMap/octomap/issues/65) I added the following option to the main cmakelists :
**BUILD_OCTOVIS_SUBPROJECT**

If it's ON (_default_) everything remains the same behaviour as people expect it.
If it's turned off, only  the octomap project will be built and missing QGLViewer and/or OpenGL are not an issue. For standalone builds this is the same as running cmake from the subfolder octomap/octomap/.

But it comes in handy when octomap is used as an external project in a
cmake-project, then the option can be passed in the cmake_args, e.g. : 

> ExternalProject_Add(
>   octomap-1.6.6
>   URL https://github.com/OctoMap/octomap/archive/v1.6.6.tar.gz
>        CMAKE_ARGS -DBUILD_OCTOVIS_SUBPROJECT=OFF
> )

This allows to download the project from GitHub instead of having to package the octomap subfolder on it's own with the project and not having to write any CMAKE syntax that refers to hardcoded folder structures which could be subject to change.

I tested it on CMAKE 2.8 on a windows system.

CMAKE option command :  (http://www.cmake.org/cmake/help/v2.8.8/cmake.html#command:option)
