### PR TITLE
add a flag (-g) to graph2tree to indicate that the nodes are already transformed in global coordinates

### DIFF
--- a/octomap/src/CMakeLists.txt
+++ b/octomap/src/CMakeLists.txt
@@ -57,6 +57,9 @@ TARGET_LINK_LIBRARIES(normals_example octomap)
 ADD_EXECUTABLE(intersection_example intersection_example.cpp)
 TARGET_LINK_LIBRARIES(intersection_example octomap)
 
+ADD_EXECUTABLE(octree2pointcloud octree2pointcloud.cpp)
+TARGET_LINK_LIBRARIES(octree2pointcloud octomap)
+
 
 # installation:
 # store all header files to install:

--- a/octomap/src/graph2tree.cpp
+++ b/octomap/src/graph2tree.cpp
@@ -57,6 +57,7 @@ void printUsage(char* self){
             "  -m <maxrange> (optional) \n"
             "  -n <max scan no.> (optional) \n"
             "  -log (enable a detailed log file with statistics) \n"
+            "  -g (nodes are already in global coordinates and no transformation is required) \n"
             "  -compressML (enable maximum-likelihood compression (lossy) after every scan)\n"
             "  -simple (simple scan insertion ray by ray instead of optimized) \n"
             "  -discretize (approximate raycasting on discretized coordinates, speeds up insertion) \n"
@@ -112,6 +113,7 @@ int main(int argc, char** argv) {
   bool detailedLog = false;
   bool simpleUpdate = false;
   bool discretize = false;
+  bool dontTransformNodes = false;
   unsigned char compression = 1;
 
   // get default sensor model values:
@@ -137,6 +139,8 @@ int main(int argc, char** argv) {
       res = atof(argv[++arg]);
     else if (! strcmp(argv[arg], "-log"))
       detailedLog = true;
+    else if (! strcmp(argv[arg], "-g"))
+      dontTransformNodes = true;
     else if (! strcmp(argv[arg], "-simple"))
       simpleUpdate = true;
     else if (! strcmp(argv[arg], "-discretize"))
@@ -205,6 +209,7 @@ int main(int argc, char** argv) {
   }
 
   // transform pointclouds first, so we can directly operate on them later
+  if (!dontTransformNodes)
   for (ScanGraph::iterator scan_it = graph->begin(); scan_it != graph->end(); scan_it++) {
 
     pose6d frame_origin = (*scan_it)->pose;

--- a/octomap/src/octree2pointcloud.cpp
+++ b/octomap/src/octree2pointcloud.cpp
@@ -1,0 +1,98 @@
+/*
+ * OctoMap - An Efficient Probabilistic 3D Mapping Framework Based on Octrees
+ * http://octomap.github.com/
+ *
+ * Copyright (c) 2009-2013, K.M. Wurm and A. Hornung, University of Freiburg
+ * All rights reserved.
+ * License: New BSD
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the University of Freiburg nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+
+#include <octomap/octomap.h>
+#include <octomap/octomap_timing.h>
+
+using namespace std;
+using namespace octomap;
+
+void printUsage(char* self){
+  std::cerr << "USAGE: " << self << " <InputFile.bt> <OutputFile.pcd>\n";
+  std::cerr << "This tool creates a point cloud of the occupied cells\n";
+  exit(0);
+}
+
+
+int main(int argc, char** argv) {
+  // default values:
+  double res = 0.1;
+
+  if (argc != 3)
+    printUsage(argv[0]);
+
+  string inputFilename = argv[1];
+  string outputFilename = argv[2];
+
+  OcTree* tree = new OcTree(0.1);
+  if (!tree->readBinary(inputFilename)){
+    OCTOMAP_ERROR("Could not open file, exiting.\n");
+    exit(1);
+  }
+  
+  res = tree->getResolution();
+  std::vector<point3d> pcl;
+
+  for (OcTree::iterator it = tree->begin(res); it != tree->end(); ++it)
+  {
+    if(tree->isNodeOccupied(*it))
+    {
+      pcl.push_back(point3d(it.getX(), it.getY(), it.getZ()));
+    }
+  }
+
+  delete tree;
+
+  ofstream f(outputFilename.c_str(), ofstream::out);
+  f << "# .PCD v0.7" << endl
+    << "VERSION 0.7" << endl
+    << "FIELDS x y z" << endl
+    << "SIZE 4 4 4" << endl
+    << "TYPE F F F" << endl
+    << "COUNT 1 1 1" << endl
+    << "WIDTH " << pcl.size() << endl
+    << "HEIGHT 1" << endl
+    << "VIEWPOINT 0 0 0 0 0 0 1" << endl
+    << "POINTS " << pcl.size() << endl
+    << "DATA ascii" << endl;
+  for(size_t i = 0; i < pcl.size(); i++)
+      f << pcl[i].x() << " " << pcl[i].y() << " " << pcl[i].z() << endl;
+  f.close();
+  
+  return 0;
+}


### PR DESCRIPTION
In some cases I have the robot position and the scan points already expressed in the global frame.

In this scenario it is much effort to make change my scan graph to be "relative" rather than skipping the transformation part in graph2tree (commit adds only 5 lines of code in octomap/src/graph2tree.cpp).