### PR TITLE
Fix -Wredeclared-class-member warnings

### DIFF
--- a/octomap/include/octomap/OcTreeBaseImpl.h
+++ b/octomap/include/octomap/OcTreeBaseImpl.h
@@ -259,9 +259,6 @@ namespace octomap {
     /// Pruning the tree first produces smaller files (lossless compression)
     std::ostream& writeData(std::ostream &s) const;
 
-    class leaf_iterator;
-    class tree_iterator;
-    class leaf_bbx_iterator;
     typedef leaf_iterator iterator;
 
     /// @return beginning of the tree as leaf iterator


### PR DESCRIPTION
Remove needless forward declare that were defined after the implementation had already been included, causing warnings when compiling with -Wredeclared-class-member.

This occurs when doing:

```c++
struct A { struct B{}; struct B; };
```