### PR TITLE
OCTREEX64: Add failing unit test.

### DIFF
--- a/octomap/src/testing/CMakeLists.txt
+++ b/octomap/src/testing/CMakeLists.txt
@@ -29,6 +29,9 @@ TARGET_LINK_LIBRARIES(test_mapcollection octomap octomath)
 ADD_EXECUTABLE(test_pruning test_pruning.cpp)
 TARGET_LINK_LIBRARIES(test_pruning octomap octomath)
 
+ADD_EXECUTABLE(test_octree_x64 test_octree_x64.cpp  octreex64.h octreex64.cpp)
+TARGET_LINK_LIBRARIES(test_octree_x64 octomap)
+
 
 # CTest tests below
 

--- a/octomap/src/testing/octreex64.cpp
+++ b/octomap/src/testing/octreex64.cpp
@@ -1,0 +1,27 @@
+#include "octreex64.h"
+
+TimestampType OcTreeX64::getLastUpdateTime() {
+  // this value is updated whenever inner nodes are
+  // updated using updateOccupancyChildren()
+  return root->getTimestamp();
+}
+
+void OcTreeX64::degradeOutdatedNodes(unsigned int time_thres_ms) {
+  for(leaf_iterator it = this->begin_leafs(), end=this->end_leafs();
+      it!= end; ++it) {
+    if (isNodeOccupied(*it) && time_thres_ms > 5000) {
+      integrateMissNoTime(&*it);
+    }
+  }
+}
+
+void OcTreeX64::updateNodeLogOdds(OcTreeX64Node* node, const float& update) const {
+  LegacyTree::updateNodeLogOdds(node, update);
+  node->updateTimestamp();
+}
+
+void OcTreeX64::integrateMissNoTime(OcTreeX64Node *node) const{
+  LegacyTree::updateNodeLogOdds(node, prob_miss_log);
+}
+
+OcTreeX64::StaticMemberInitializer OcTreeX64::OcTreeX64MemberInit;

--- a/octomap/src/testing/octreex64.h
+++ b/octomap/src/testing/octreex64.h
@@ -1,0 +1,91 @@
+#ifndef OCTREEX64_H
+#define OCTREEX64_H
+
+#include <octomap/OcTreeNode.h>
+#include <octomap/OccupancyOcTreeBase.h>
+
+typedef int64_t TimestampType;
+typedef octomap::OcTreeNode LegacyNode;
+// node definition
+class OcTreeX64Node : public LegacyNode {
+
+public:
+    OcTreeX64Node() : LegacyNode(), timestamp() {}
+
+    OcTreeX64Node(const OcTreeX64Node& rhs) : LegacyNode(rhs),
+        timestamp(rhs.timestamp) {}
+
+    bool operator==(const OcTreeX64Node& rhs) const{
+        return (rhs.value == value && rhs.timestamp == timestamp);
+    }
+
+    // children
+    inline OcTreeX64Node* getChild(unsigned int i) {
+        return static_cast<OcTreeX64Node*> (LegacyNode::getChild(i));
+    }
+    inline const OcTreeX64Node* getChild(unsigned int i) const {
+        return static_cast<const OcTreeX64Node*> (LegacyNode::getChild(i));
+    }
+
+    bool createChild(unsigned int i) {
+        if (children == NULL) allocChildren();
+        children[i] = new OcTreeX64Node();
+        return true;
+    }
+
+    // timestamp
+    inline TimestampType getTimestamp() const { return timestamp; }
+    inline void updateTimestamp() { timestamp = 1000;}
+    inline void setTimestamp(TimestampType timestamp) {this->timestamp = timestamp; }
+
+    // update occupancy and timesteps of inner nodes
+    inline void updateOccupancyChildren() {
+        this->setLogOdds(this->getMaxChildLogOdds());  // conservative
+        updateTimestamp();
+    }
+
+protected:
+    TimestampType timestamp;
+};
+
+
+typedef octomap::OccupancyOcTreeBase<OcTreeX64Node> LegacyTree;
+// tree definition
+class OcTreeX64 : public LegacyTree {
+
+public:
+    /// Default constructor, sets resolution of leafs
+    OcTreeX64(double resolution) : LegacyTree(resolution) {}
+
+    /// virtual constructor: creates a new object of same type
+    /// (Covariant return type requires an up-to-date compiler)
+    OcTreeX64* create() const {return new OcTreeX64(resolution); }
+
+    std::string getTreeType() const {return "OcTree";}
+
+    //! \return timestamp of last update
+    TimestampType getLastUpdateTime();
+
+    void degradeOutdatedNodes(unsigned int time_thres);
+
+    virtual void updateNodeLogOdds(OcTreeX64Node* node, const float& update) const;
+    void integrateMissNoTime(OcTreeX64Node* node) const;
+
+protected:
+    /**
+     * Static member object which ensures that this OcTree's prototype
+     * ends up in the classIDMapping only once
+     */
+    class StaticMemberInitializer{
+    public:
+        StaticMemberInitializer() {
+            OcTreeX64* tree = new OcTreeX64(0.1);
+            AbstractOcTree::registerTreeType(tree);
+        }
+    };
+    /// to ensure static initialization (only once)
+    static StaticMemberInitializer OcTreeX64MemberInit;
+
+};
+
+#endif // OCTREEX64_H

--- a/octomap/src/testing/test_octree_x64.cpp
+++ b/octomap/src/testing/test_octree_x64.cpp
@@ -1,0 +1,29 @@
+
+#include <octomap/octomap.h>
+#include "octreex64.h"
+#include "testing.h"
+
+using namespace std;
+using namespace octomap;
+
+int main(int argc, char** argv) {
+  const float res = 0.05f;
+  OcTreeX64 tree(res);
+  const float step = res;
+  float x = 0.0f;
+  octomap::point3d origin(-1.0, 1.0, 1.2);
+  for (float y = 0.0f; y < 2.0f; y = y + step) {
+    for (float z = -1.0f; z < 1.0f; z = z + step) {
+      octomap::point3d end(x, y, z);
+      tree.insertRay(origin, end);
+    }
+  }
+  x = 1.0f;
+  for (float y = 1.0f; y < 3.0f; y = y + step) {
+    for (float z = -2.0f; z < 2.0f; z = z + step) {
+        octomap::point3d end(x, y, z);
+        tree.insertRay(origin, end);
+    }
+  }
+  std::cout << "SUCCESS\n";
+}


### PR DESCRIPTION
This PR contains the definition of a OctreeX64 that uses OcTreeX64Node.
OcTreeX64Node inherits from regular OcTreeNode and adds a timestamp stored as a int64_t.

The purpose of this PR is to demonstrate that in some cases, we get an exception thrown while using 64 bits members in node classes.