### PR TITLE
Virtual octreedatanode

### DIFF
--- a/octomap/include/octomap/OcTreeDataNode.h
+++ b/octomap/include/octomap/OcTreeDataNode.h
@@ -62,7 +62,7 @@ namespace octomap {
     /// Copy constructor, performs a recursive deep-copy of all children
     OcTreeDataNode(const OcTreeDataNode& rhs);
 
-    ~OcTreeDataNode();
+    virtual ~OcTreeDataNode();
 
     /// Equals operator, compares if the stored value is identical
     bool operator==(const OcTreeDataNode& rhs) const;
@@ -80,10 +80,10 @@ namespace octomap {
     bool childExists(unsigned int i) const;
 
     /// \return a pointer to the i-th child of the node. The child needs to exist.
-    OcTreeDataNode<T>* getChild(unsigned int i);
+    virtual OcTreeDataNode<T>* getChild(unsigned int i);
 
     /// \return a const pointer to the i-th child of the node. The child needs to exist.
-    const OcTreeDataNode<T>* getChild(unsigned int i) const;
+    virtual const OcTreeDataNode<T>* getChild(unsigned int i) const;
 
     /// \return true if the node has at least one child
     bool hasChildren() const;

--- a/octomap/include/octomap/OcTreeDataNode.h
+++ b/octomap/include/octomap/OcTreeDataNode.h
@@ -72,7 +72,7 @@ namespace octomap {
 
 
     /// initialize i-th child, allocate children array if needed
-    bool createChild(unsigned int i);
+    virtual bool createChild(unsigned int i);
 
     /// Safe test to check of the i-th child exists,
     /// first tests if there are any children.
@@ -146,7 +146,7 @@ namespace octomap {
 
 
   protected:
-    void allocChildren();
+    virtual void allocChildren();
 
     /// pointer to array of children, may be NULL
     OcTreeDataNode<T>** children;

--- a/octomap/include/octomap/OcTreeNode.h
+++ b/octomap/include/octomap/OcTreeNode.h
@@ -58,11 +58,19 @@ namespace octomap {
     bool createChild(unsigned int i);
 
     // overloaded, so that the return type is correct:
-    inline OcTreeNode* getChild(unsigned int i) {
-      return static_cast<OcTreeNode*> (OcTreeDataNode<float>::getChild(i));
+    virtual inline OcTreeNode* getChild(unsigned int i) {
+      OcTreeDataNode<float>* child = OcTreeDataNode<float>::getChild(i);
+      OcTreeNode* toreturn = dynamic_cast<OcTreeNode*> (child);
+      assert(toreturn != NULL);
+      return toreturn;
+//      return static_cast<OcTreeNode*> (OcTreeDataNode<float>::getChild(i));
     }
-    inline const OcTreeNode* getChild(unsigned int i) const {
-      return static_cast<const OcTreeNode*> (OcTreeDataNode<float>::getChild(i));
+    virtual inline const OcTreeNode* getChild(unsigned int i) const {
+      const OcTreeDataNode<float>* child = OcTreeDataNode<float>::getChild(i);
+      const OcTreeNode* toreturn = dynamic_cast<const OcTreeNode*> (child);
+      assert(toreturn != NULL);
+      return toreturn;
+//      return static_cast<const OcTreeNode*> (OcTreeDataNode<float>::getChild(i));
     }
 
     // -- node occupancy  ----------------------------

--- a/octomap/include/octomap/OcTreeNode.h
+++ b/octomap/include/octomap/OcTreeNode.h
@@ -55,7 +55,7 @@ namespace octomap {
     OcTreeNode();
     ~OcTreeNode();
 
-    bool createChild(unsigned int i);
+    virtual bool createChild(unsigned int i);
 
     // overloaded, so that the return type is correct:
     virtual inline OcTreeNode* getChild(unsigned int i) {
@@ -104,6 +104,7 @@ namespace octomap {
 
   protected:
     // "value" stores log odds occupancy probability
+
   };
 
 } // end namespace

--- a/octomap/include/octomap/OcTreeNode.h
+++ b/octomap/include/octomap/OcTreeNode.h
@@ -53,6 +53,7 @@ namespace octomap {
 
   public:
     OcTreeNode();
+    OcTreeNode(const OcTreeNode& rhs);
     ~OcTreeNode();
 
     virtual bool createChild(unsigned int i);

--- a/octomap/src/OcTreeNode.cpp
+++ b/octomap/src/OcTreeNode.cpp
@@ -46,6 +46,22 @@ namespace octomap {
   {
   }
 
+  OcTreeNode::OcTreeNode(const OcTreeNode& rhs)
+  {
+    children = NULL;
+    value = rhs.value;
+    if (rhs.hasChildren()){
+      allocChildren();
+      for (unsigned i = 0; i<8; ++i){
+        if (rhs.children[i]) {
+          OcTreeNode* casted_down = dynamic_cast<OcTreeNode*>(rhs.children[i]);
+          assert(casted_down != NULL);
+          children[i] = new OcTreeNode(*casted_down);
+        }
+      }
+    }
+  }
+
   OcTreeNode::~OcTreeNode(){
   }
 


### PR DESCRIPTION
Subclassing OcTreeNode is still problematic, since no method is virtual and the class is not polymorphic. The main problem is with static_cast in OcTreeNode::createChild, where any information about a subclass is lost. Effectively creating a subclass is still not very easy, as a number of methods need to be rewritten (including the copy constructor) but these changes allow for polymorphism, thus easier extension of the node.

This pull request should solve issue #93 and potentially #95 

Merry Christmas! :smile: :christmas_tree: 