### PR TITLE
Proposed fixes for IO factory class registry with MSVC (#51)

### DIFF
--- a/octomap/include/octomap/ColorOcTree.h
+++ b/octomap/include/octomap/ColorOcTree.h
@@ -117,7 +117,7 @@ namespace octomap {
 
   public:
     /// Default constructor, sets resolution of leafs
-    ColorOcTree(double resolution) : OccupancyOcTreeBase<ColorOcTreeNode>(resolution) {};  
+    ColorOcTree(double resolution);
       
     /// virtual constructor: creates a new object of same type
     /// (Covariant return type requires an up-to-date compiler)
@@ -180,6 +180,13 @@ namespace octomap {
            ColorOcTree* tree = new ColorOcTree(0.1);
            AbstractOcTree::registerTreeType(tree);
          }
+
+         /**
+         * Dummy function to ensure that MSVC does not drop the
+         * StaticMemberInitializer, causing this tree failing to register.
+         * Needs to be called from the constructor of this octree.
+         */
+         void ensureLinking() {};
     };
     /// static member to ensure static initialization (only once)
     static StaticMemberInitializer colorOcTreeMemberInit;

--- a/octomap/include/octomap/ColorOcTree.h
+++ b/octomap/include/octomap/ColorOcTree.h
@@ -172,7 +172,10 @@ namespace octomap {
 
     /**
      * Static member object which ensures that this OcTree's prototype
-     * ends up in the classIDMapping only once
+     * ends up in the classIDMapping only once. You need this as a 
+     * static member in any derived octree class in order to read .ot
+     * files through the AbstractOcTree factory. You should also call
+     * ensureLinking() once from the constructor.
      */
     class StaticMemberInitializer{
        public:

--- a/octomap/include/octomap/CountingOcTree.h
+++ b/octomap/include/octomap/CountingOcTree.h
@@ -104,7 +104,10 @@ namespace octomap {
 
     /**
      * Static member object which ensures that this OcTree's prototype
-     * ends up in the classIDMapping only once
+     * ends up in the classIDMapping only once. You need this as a 
+     * static member in any derived octree class in order to read .ot
+     * files through the AbstractOcTree factory. You should also call
+     * ensureLinking() once from the constructor.
      */
     class StaticMemberInitializer{
        public:

--- a/octomap/include/octomap/CountingOcTree.h
+++ b/octomap/include/octomap/CountingOcTree.h
@@ -89,7 +89,7 @@ namespace octomap {
 
   public:
     /// Default constructor, sets resolution of leafs
-    CountingOcTree(double resolution) : OcTreeBase<CountingOcTreeNode>(resolution) {};    
+    CountingOcTree(double resolution);
     virtual CountingOcTreeNode* updateNode(const point3d& value);
     CountingOcTreeNode* updateNode(const OcTreeKey& k);
     void getCentersMinHits(point3d_list& node_centers, unsigned int min_hits) const;
@@ -112,6 +112,13 @@ namespace octomap {
            CountingOcTree* tree = new CountingOcTree(0.1);
            AbstractOcTree::registerTreeType(tree);
          }
+
+         /**
+         * Dummy function to ensure that MSVC does not drop the
+         * StaticMemberInitializer, causing this tree failing to register.
+         * Needs to be called from the constructor of this octree.
+         */
+         void ensureLinking() {};
     };
     /// static member to ensure static initialization (only once)
     static StaticMemberInitializer countingOcTreeMemberInit;

--- a/octomap/include/octomap/OcTree.h
+++ b/octomap/include/octomap/OcTree.h
@@ -50,7 +50,7 @@ namespace octomap {
 
   public:
     /// Default constructor, sets resolution of leafs
-    OcTree(double resolution) : OccupancyOcTreeBase<OcTreeNode>(resolution) {};
+    OcTree(double resolution);
 
     /**
      * Reads an OcTree from a binary file 
@@ -79,7 +79,15 @@ namespace octomap {
         OcTree* tree = new OcTree(0.1);
         AbstractOcTree::registerTreeType(tree);
       }
+
+	    /**
+	     * Dummy function to ensure that MSVC does not drop the
+	     * StaticMemberInitializer, causing this tree failing to register.
+	     * Needs to be called from the constructor of this octree.
+	     */
+	    void ensureLinking() {};
     };
+
     /// to ensure static initialization (only once)
     static StaticMemberInitializer ocTreeMemberInit;
   };

--- a/octomap/include/octomap/OcTree.h
+++ b/octomap/include/octomap/OcTree.h
@@ -71,7 +71,10 @@ namespace octomap {
   protected:
     /**
      * Static member object which ensures that this OcTree's prototype
-     * ends up in the classIDMapping only once
+     * ends up in the classIDMapping only once. You need this as a 
+     * static member in any derived octree class in order to read .ot
+     * files through the AbstractOcTree factory. You should also call
+     * ensureLinking() once from the constructor.
      */
     class StaticMemberInitializer{
     public:

--- a/octomap/include/octomap/OcTreeStamped.h
+++ b/octomap/include/octomap/OcTreeStamped.h
@@ -88,7 +88,7 @@ namespace octomap {
 
   public:
     /// Default constructor, sets resolution of leafs
-    OcTreeStamped(double resolution) : OccupancyOcTreeBase<OcTreeNodeStamped>(resolution) {};    
+	  OcTreeStamped(double resolution);
       
     /// virtual constructor: creates a new object of same type
     /// (Covariant return type requires an up-to-date compiler)
@@ -115,6 +115,13 @@ namespace octomap {
         OcTreeStamped* tree = new OcTreeStamped(0.1);
         AbstractOcTree::registerTreeType(tree);
       }
+
+      /**
+      * Dummy function to ensure that MSVC does not drop the
+      * StaticMemberInitializer, causing this tree failing to register.
+      * Needs to be called from the constructor of this octree.
+      */
+      void ensureLinking() {};
     };
     /// to ensure static initialization (only once)
     static StaticMemberInitializer ocTreeStampedMemberInit;

--- a/octomap/include/octomap/OcTreeStamped.h
+++ b/octomap/include/octomap/OcTreeStamped.h
@@ -107,7 +107,10 @@ namespace octomap {
   protected:
     /**
      * Static member object which ensures that this OcTree's prototype
-     * ends up in the classIDMapping only once
+     * ends up in the classIDMapping only once. You need this as a 
+     * static member in any derived octree class in order to read .ot
+     * files through the AbstractOcTree factory. You should also call
+     * ensureLinking() once from the constructor.
      */
     class StaticMemberInitializer{
     public:

--- a/octomap/src/ColorOcTree.cpp
+++ b/octomap/src/ColorOcTree.cpp
@@ -130,6 +130,10 @@ namespace octomap {
   }
 
   // tree implementation  --------------------------------------
+  ColorOcTree::ColorOcTree(double resolution)
+  : OccupancyOcTreeBase<ColorOcTreeNode>(resolution) {
+    colorOcTreeMemberInit.ensureLinking();
+  };
 
   ColorOcTreeNode* ColorOcTree::setNodeColor(const OcTreeKey& key, 
                                              const unsigned char& r, 

--- a/octomap/src/CountingOcTree.cpp
+++ b/octomap/src/CountingOcTree.cpp
@@ -70,7 +70,10 @@ namespace octomap {
 
 
   /// implementation of CountingOcTree  --------------------------------------
-
+  CountingOcTree::CountingOcTree(double resolution)
+   : OcTreeBase<CountingOcTreeNode>(resolution) {
+      countingOcTreeMemberInit.ensureLinking();
+   }
 
   CountingOcTreeNode* CountingOcTree::updateNode(const point3d& value) {
 

--- a/octomap/src/OcTree.cpp
+++ b/octomap/src/OcTree.cpp
@@ -36,6 +36,11 @@
 
 namespace octomap {
 
+	OcTree::OcTree(double resolution) 
+		: OccupancyOcTreeBase<OcTreeNode>(resolution) {
+		ocTreeMemberInit.ensureLinking();
+	};
+
   OcTree::OcTree(std::string _filename)
     : OccupancyOcTreeBase<OcTreeNode> (0.1)  { // resolution will be set according to tree file
     readBinary(_filename);

--- a/octomap/src/OcTreeStamped.cpp
+++ b/octomap/src/OcTreeStamped.cpp
@@ -35,6 +35,11 @@
 
 namespace octomap {
 
+  OcTreeStamped::OcTreeStamped(double resolution)
+   : OccupancyOcTreeBase<OcTreeNodeStamped>(resolution) {
+    ocTreeStampedMemberInit.ensureLinking();
+  }
+
   unsigned int OcTreeStamped::getLastUpdateTime() {
     // this value is updated whenever inner nodes are 
     // updated using updateOccupancyChildren()

--- a/octomap/src/testing/test_io.cpp
+++ b/octomap/src/testing/test_io.cpp
@@ -3,6 +3,7 @@
 
 #include <octomap/OcTree.h>
 #include <octomap/ColorOcTree.h>
+#include <octomap/OcTreeStamped.h>
 #include <octomap/math/Utils.h>
 #include "testing.h"
  
@@ -32,10 +33,8 @@ int main(int argc, char** argv) {
   EXPECT_EQ(emptyReadTree.size(), 0);
   EXPECT_TRUE(emptyTree == emptyReadTree);
 
-
-
   string filename = string(argv[1]);
-
+  
   string filenameOt = "test_io_file.ot";
   string filenameBtOut = "test_io_file.bt";
   string filenameBtCopyOut = "test_io_file_copy.bt";
@@ -104,28 +103,57 @@ int main(int argc, char** argv) {
 
   EXPECT_FALSE(tree == *readTreeOt);
 
-  // simple test for tree headers (color)
-  double res = 0.02;
-  std::string filenameColor = "test_io_color_file.ot";
-  ColorOcTree colorTree(res);
-  EXPECT_EQ(colorTree.getTreeType(), "ColorOcTree");
-  ColorOcTreeNode* colorNode = colorTree.updateNode(point3d(0.0, 0.0, 0.0), true);
-  ColorOcTreeNode::Color color_red(255, 0, 0);
-  colorNode->setColor(color_red);
-  colorTree.setNodeColor(0.0, 0.0, 0.0, 255, 0, 0);
-  colorTree.updateNode(point3d(0.1f, 0.1f, 0.1f), true);
-  colorTree.setNodeColor(0.1f, 0.1f, 0.1f, 0, 0, 255);
+  // Test for tree headers and IO factory registry (color)
+  {
+    double res = 0.02;
+    std::string filenameColor = "test_io_color_file.ot";
+    ColorOcTree colorTree(res);
+    EXPECT_EQ(colorTree.getTreeType(), "ColorOcTree");
+    ColorOcTreeNode* colorNode = colorTree.updateNode(point3d(0.0, 0.0, 0.0), true);
+    ColorOcTreeNode::Color color_red(255, 0, 0);
+    colorNode->setColor(color_red);
+    colorTree.setNodeColor(0.0, 0.0, 0.0, 255, 0, 0);
+    colorTree.updateNode(point3d(0.1f, 0.1f, 0.1f), true);
+    colorTree.setNodeColor(0.1f, 0.1f, 0.1f, 0, 0, 255);
 
-  EXPECT_TRUE(colorTree.write(filenameColor));
-  readTreeAbstract = AbstractOcTree::read(filenameColor);
+    EXPECT_TRUE(colorTree.write(filenameColor));
+    readTreeAbstract = AbstractOcTree::read(filenameColor);
+    EXPECT_TRUE(readTreeAbstract);
+    EXPECT_EQ(colorTree.getTreeType(),  readTreeAbstract->getTreeType());
+    ColorOcTree* readColorTree = dynamic_cast<ColorOcTree*>(readTreeAbstract);
+    EXPECT_TRUE(readColorTree);
+    EXPECT_TRUE(colorTree == *readColorTree);
+    colorNode = colorTree.search(0.0, 0.0, 0.0);
+    EXPECT_TRUE(colorNode);
+    EXPECT_EQ(colorNode->getColor(), color_red);
+    delete readColorTree;
+  }
+
+  // Test for tree headers and IO factory registry (stamped)
+  double res = 0.05;
+  std::string filenameStamped = "test_io_stamped_file.ot";
+  OcTreeStamped stampedTree(res);
+  EXPECT_EQ(stampedTree.getTreeType(), "OcTreeStamped");
+  // TODO: add / modify some stamped nodes
+  //ColorOcTreeNode* colorNode = colorTree.updateNode(point3d(0.0, 0.0, 0.0), true);
+  //ColorOcTreeNode::Color color_red(255, 0, 0);
+  //colorNode->setColor(color_red);
+  //colorTree.setNodeColor(0.0, 0.0, 0.0, 255, 0, 0);
+  //colorTree.updateNode(point3d(0.1f, 0.1f, 0.1f), true);
+  //colorTree.setNodeColor(0.1f, 0.1f, 0.1f, 0, 0, 255);
+
+  EXPECT_TRUE(stampedTree.write(filenameStamped));
+  readTreeAbstract = NULL;
+  readTreeAbstract = AbstractOcTree::read(filenameStamped);
   EXPECT_TRUE(readTreeAbstract);
-  EXPECT_EQ(colorTree.getTreeType(),  readTreeAbstract->getTreeType());
-  ColorOcTree* readColorTree = dynamic_cast<ColorOcTree*>(readTreeAbstract);
-  EXPECT_TRUE(readColorTree);
-  EXPECT_TRUE(colorTree == *readColorTree);
-  colorNode = colorTree.search(0.0, 0.0, 0.0);
-  EXPECT_TRUE(colorNode);
-  EXPECT_EQ(colorNode->getColor(), color_red);
+  EXPECT_EQ(stampedTree.getTreeType(), readTreeAbstract->getTreeType());
+  OcTreeStamped* readStampedTree = dynamic_cast<OcTreeStamped*>(readTreeAbstract);
+  EXPECT_TRUE(readStampedTree);
+  EXPECT_TRUE(stampedTree == *readStampedTree);
+  //colorNode = colorTree.search(0.0, 0.0, 0.0);
+  //EXPECT_TRUE(colorNode);
+  //EXPECT_EQ(colorNode->getColor(), color_red);
+
 
 
 


### PR DESCRIPTION
Explicitly calling a dummy function from c'tor ensures that MSVC does
not optimize the StaticMemberInitializer away. Extended and verified
test_io to read / write OcTree, ColorOcTree and OcTreeStamped.