### PR TITLE
OCTREE: Bug when deleting all nodes.

### DIFF
--- a/octomap/src/testing/CMakeLists.txt
+++ b/octomap/src/testing/CMakeLists.txt
@@ -30,6 +30,9 @@ ADD_EXECUTABLE(test_pruning test_pruning.cpp)
 TARGET_LINK_LIBRARIES(test_pruning octomap octomath)
 
 
+ADD_EXECUTABLE(test_bbox_empty_octree test_bbox_empty_octree.cpp)
+TARGET_LINK_LIBRARIES(test_bbox_empty_octree octomap octomath)
+
 # CTest tests below
 
 ADD_EXECUTABLE(unit_tests unit_tests.cpp)

--- a/octomap/src/testing/test_bbox_empty_octree.cpp
+++ b/octomap/src/testing/test_bbox_empty_octree.cpp
@@ -1,0 +1,15 @@
+#include <octomap/octomap.h>
+
+int main(int argc, char** argv) {
+  octomap::OcTree tree(0.1);
+  octomap::point3d ptMinbbx(-0.1, -0.1, -0.1);
+  octomap::point3d ptMaxbbx(0.1, 0.1, 0.1);
+  const float clampingThreshold = tree.getClampingThresMinLog();
+  for (octomap::OcTree::leaf_bbx_iterator it =
+       tree.begin_leafs_bbx(ptMinbbx, ptMaxbbx),
+       end = tree.end_leafs_bbx();
+       it != end; ++it) {
+    it->setLogOdds(clampingThreshold);
+  }
+  return 0;
+}


### PR DESCRIPTION
This PR highlights a weird behaviour when deleting all nodes from an octree.

Root node remains with a very high size (6553.6). This leads to a big memory allocation when expanding this node.