### PR TITLE
remove qglviewer.h header dependency from some public headers

### DIFF
--- a/octovis/include/octovis/CameraFollowMode.h
+++ b/octovis/include/octovis/CameraFollowMode.h
@@ -26,6 +26,7 @@
 #define CAMERAFOLLOWMODE_H_
 
 #include "SceneObject.h"
+#include <QObject>
 
 class CameraFollowMode : public QObject {
   Q_OBJECT

--- a/octovis/include/octovis/SceneObject.h
+++ b/octovis/include/octovis/SceneObject.h
@@ -37,7 +37,6 @@
   #include <GL/glu.h>
 #endif
 
-#include <qglviewer.h>
 #include <octomap/octomap.h>
 
 namespace octomap {

--- a/octovis/include/octovis/ViewerSettingsPanel.h
+++ b/octovis/include/octovis/ViewerSettingsPanel.h
@@ -26,7 +26,7 @@
 #define VIEWERSETTINGSPANEL_H
 
 #include <math.h>
-#include <qglviewer.h>
+#include <QWidget>
 #include "ui_ViewerSettingsPanel.h"
 
 #define _TREE_MAX_DEPTH 16

--- a/octovis/src/OcTreeDrawer.cpp
+++ b/octovis/src/OcTreeDrawer.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <octovis/OcTreeDrawer.h>
+#include <qglviewer.h>
 
 #define OTD_RAD2DEG 57.2957795
 


### PR DESCRIPTION
Some octovis headers include qglviewer.h unnecessarily.  By removing
the header dependency it is easier to include octovis headers without
requiring an include path for qglviewer.

This commit could break user code that relies on the header, but those
compile errors will be easy to fix.