### PR TITLE
Enable maximum tree depth of 32 (..)

### DIFF
--- a/octomap/include/octomap/OcTree.h
+++ b/octomap/include/octomap/OcTree.h
@@ -52,8 +52,12 @@ namespace octomap {
     /// Default constructor, sets resolution of leafs
     OcTree(double resolution);
 
+    /// Constructor to enable derived classes to change tree constants.
+    OcTree(double resolution, unsigned int tree_depth, unsigned int tree_max_val)
+        : OccupancyOcTreeBase<OcTreeNode>(resolution,tree_depth, tree_max_val) {};
+
     /**
-     * Reads an OcTree from a binary file 
+     * Reads an OcTree from a binary file
     * @param _filename
      *
      */

--- a/octomap/include/octomap/OcTreeBaseImpl.h
+++ b/octomap/include/octomap/OcTreeBaseImpl.h
@@ -78,7 +78,7 @@ namespace octomap {
     // the actual iterator implementation is included here
     // as a member from this file
     #include <octomap/OcTreeIterator.hxx>
-    
+
     OcTreeBaseImpl(double resolution);
     virtual ~OcTreeBaseImpl();
 
@@ -116,7 +116,7 @@ namespace octomap {
      */
     inline NODE* getRoot() const { return root; }
 
-    /** 
+    /**
      *  Search node at specified depth given a 3d point (depth=0: search full tree depth).
      *  You need to check if the returned node is NULL, since it can be in unknown space.
      *  @return pointer to node if found, NULL otherwise
@@ -144,14 +144,14 @@ namespace octomap {
      */
     bool deleteNode(double x, double y, double z, unsigned int depth = 0);
 
-    /** 
+    /**
      *  Delete a node (if exists) given a 3d point. Will always
      *  delete at the lowest level unless depth !=0, and expand pruned inner nodes as needed.
      *  Pruned nodes at level "depth" will directly be deleted as a whole.
      */
     bool deleteNode(const point3d& value, unsigned int depth = 0);
 
-    /** 
+    /**
      *  Delete a node (if exists) given an addressing key. Will always
      *  delete at the lowest level unless depth !=0, and expand pruned inner nodes as needed.
      *  Pruned nodes at level "depth" will directly be deleted as a whole.
@@ -236,7 +236,7 @@ namespace octomap {
     * coordinates of all nodes traversed by the beam. You still need to check
     * if a node at that coordinate exists (e.g. with search()).
     * @note: use the faster computeRayKeys method if possible.
-    * 
+    *
     * @param origin start coordinate of ray
     * @param end end coordinate of ray
     * @param ray KeyRay structure that holds the keys of all nodes traversed by the ray, excluding "end"
@@ -292,12 +292,12 @@ namespace octomap {
     //
 
     /// Converts from a single coordinate into a discrete key
-    inline unsigned short int coordToKey(double coordinate) const{
+    inline unsigned int coordToKey(double coordinate) const{
       return ((int) floor(resolution_factor * coordinate)) + tree_max_val;
     }
 
     /// Converts from a single coordinate into a discrete key at a given depth
-    unsigned short int coordToKey(double coordinate, unsigned depth) const;
+    unsigned int coordToKey(double coordinate, unsigned depth) const;
 
 
     /// Converts from a 3D coordinate into a 3D addressing key
@@ -350,7 +350,7 @@ namespace octomap {
      * @param depth Target depth level for the new key
      * @return Key for the new depth level
      */
-    unsigned short int adjustKeyAtDepth(unsigned short int key, unsigned int depth) const;
+    unsigned int adjustKeyAtDepth(unsigned int key, unsigned int depth) const;
 
     /**
      * Converts a 3D coordinate into a 3D OcTreeKey, with boundary checking.
@@ -401,7 +401,7 @@ namespace octomap {
      * @param key discrete 16 bit adressing key, result
      * @return true if coordinate is within the octree bounds (valid), false otherwise
      */
-    bool coordToKeyChecked(double coordinate, unsigned short int& key) const;
+    bool coordToKeyChecked(double coordinate, unsigned int& key) const;
 
     /**
      * Converts a single coordinate into a discrete addressing key, with boundary checking.
@@ -411,15 +411,15 @@ namespace octomap {
      * @param key discrete 16 bit adressing key, result
      * @return true if coordinate is within the octree bounds (valid), false otherwise
      */
-    bool coordToKeyChecked(double coordinate, unsigned depth, unsigned short int& key) const;
+    bool coordToKeyChecked(double coordinate, unsigned depth, unsigned int& key) const;
 
     /// converts from a discrete key at a given depth into a coordinate
     /// corresponding to the key's center
-    double keyToCoord(unsigned short int key, unsigned depth) const;
+    double keyToCoord(unsigned int key, unsigned depth) const;
 
     /// converts from a discrete key at the lowest tree level into a coordinate
     /// corresponding to the key's center
-    inline double keyToCoord(unsigned short int key) const{
+    inline double keyToCoord(unsigned int key) const{
       return (double( (int) key - (int) this->tree_max_val ) +0.5) * this->resolution;
     }
 
@@ -456,7 +456,7 @@ namespace octomap {
 
     /// recursive call of expand()
     void expandRecurs(NODE* node, unsigned int depth, unsigned int max_depth);
-    
+
     size_t getNumLeafNodesRecurs(const NODE* parent) const;
 
   private:
@@ -473,7 +473,7 @@ namespace octomap {
     const unsigned int tree_max_val;
     double resolution;  ///< in meters
     double resolution_factor; ///< = 1. / resolution
-  
+
     size_t tree_size; ///< number of nodes in tree
     /// flag to denote whether the octree extent changed (for lazy min/max eval)
     bool size_changed;

--- a/octomap/include/octomap/OcTreeBaseImpl.hxx
+++ b/octomap/include/octomap/OcTreeBaseImpl.hxx
@@ -47,7 +47,7 @@ namespace octomap {
     I(), root(NULL), tree_depth(16), tree_max_val(32768),
     resolution(resolution), tree_size(0)
   {
-    
+
     init();
 
     // no longer create an empty root node - only on demand
@@ -160,7 +160,7 @@ namespace octomap {
     resolution = r;
     resolution_factor = 1. / resolution;
 
-    tree_center(0) = tree_center(1) = tree_center(2) 
+    tree_center(0) = tree_center(1) = tree_center(2)
       = (float) (((double) tree_max_val) / resolution_factor);
 
     // init node size lookup table:
@@ -173,7 +173,7 @@ namespace octomap {
   }
 
   template <class NODE,class I>
-  inline unsigned short int OcTreeBaseImpl<NODE,I>::coordToKey(double coordinate, unsigned depth) const{
+  inline unsigned int OcTreeBaseImpl<NODE,I>::coordToKey(double coordinate, unsigned depth) const{
     assert (depth <= tree_depth);
     int keyval = ((int) floor(resolution_factor * coordinate));
 
@@ -186,7 +186,7 @@ namespace octomap {
 
 
   template <class NODE,class I>
-  bool OcTreeBaseImpl<NODE,I>::coordToKeyChecked(double coordinate, unsigned short int& keyval) const {
+  bool OcTreeBaseImpl<NODE,I>::coordToKeyChecked(double coordinate, unsigned int& keyval) const {
 
     // scale to resolution and shift center for tree_max_val
     int scaled_coord =  ((int) floor(resolution_factor * coordinate)) + tree_max_val;
@@ -201,7 +201,7 @@ namespace octomap {
 
 
   template <class NODE,class I>
-  bool OcTreeBaseImpl<NODE,I>::coordToKeyChecked(double coordinate, unsigned depth, unsigned short int& keyval) const {
+  bool OcTreeBaseImpl<NODE,I>::coordToKeyChecked(double coordinate, unsigned depth, unsigned int& keyval) const {
 
     // scale to resolution and shift center for tree_max_val
     int scaled_coord =  ((int) floor(resolution_factor * coordinate)) + tree_max_val;
@@ -260,7 +260,7 @@ namespace octomap {
   }
 
   template <class NODE,class I>
-  unsigned short int OcTreeBaseImpl<NODE,I>::adjustKeyAtDepth(unsigned short int key, unsigned int depth) const{
+  unsigned int OcTreeBaseImpl<NODE,I>::adjustKeyAtDepth(unsigned int key, unsigned int depth) const{
     unsigned int diff = tree_depth - depth;
 
     if(diff == 0)
@@ -270,7 +270,7 @@ namespace octomap {
   }
 
   template <class NODE,class I>
-  double OcTreeBaseImpl<NODE,I>::keyToCoord(unsigned short int key, unsigned depth) const{
+  double OcTreeBaseImpl<NODE,I>::keyToCoord(unsigned int key, unsigned depth) const{
     assert(depth <= tree_depth);
 
     // root is centered on 0 = 0.0
@@ -420,7 +420,7 @@ namespace octomap {
 
   template <class NODE,class I>
   bool OcTreeBaseImpl<NODE,I>::computeRayKeys(const point3d& origin,
-                                          const point3d& end, 
+                                          const point3d& end,
                                           KeyRay& ray) const {
 
     // see "A Faster Voxel Traversal Algorithm for Ray Tracing" by Amanatides & Woo
@@ -436,7 +436,7 @@ namespace octomap {
       return false;
     }
 
-    
+
     if (key_origin == key_end)
       return true; // same tree cell, we're done.
 
@@ -452,7 +452,7 @@ namespace octomap {
     double tMax[3];
     double tDelta[3];
 
-    OcTreeKey current_key = key_origin; 
+    OcTreeKey current_key = key_origin;
 
     for(unsigned int i=0; i < 3; ++i) {
       // compute step direction
@@ -514,14 +514,14 @@ namespace octomap {
           done = true;
           break;
         }
-        
+
         else {  // continue to add freespace cells
           ray.addKey(current_key);
         }
       }
 
       assert ( ray.size() < ray.sizeMax() - 1);
-      
+
     } // end while
 
     return true;
@@ -666,11 +666,11 @@ namespace octomap {
 
     double size_x, size_y, size_z;
     this->getMetricSize(size_x, size_y,size_z);
-    
+
     // assuming best case (one big array and efficient addressing)
     // we can avoid "ceil" since size already accounts for voxels
-    
-    // Note: this can be larger than the adressable memory 
+
+    // Note: this can be larger than the adressable memory
     //   - size_t may not be enough to hold it!
     return (unsigned long long)((size_x/resolution) * (size_y/resolution) * (size_z/resolution)
         * sizeof(root->getValue()));
@@ -678,7 +678,7 @@ namespace octomap {
   }
 
 
-  // non-const versions, 
+  // non-const versions,
   // change min/max/size_changed members
 
   template <class NODE,class I>
@@ -789,7 +789,7 @@ namespace octomap {
         if (y < my) my = y;
         if (z < mz) mz = z;
       }
-    } // end if size changed 
+    } // end if size changed
     else {
       mx = min_value[0];
       my = min_value[1];
@@ -817,7 +817,7 @@ namespace octomap {
         if (y > my) my = y;
         if (z > mz) mz = z;
       }
-    } 
+    }
     else {
       mx = max_value[0];
       my = max_value[1];
@@ -870,7 +870,7 @@ namespace octomap {
       steps[i] = floor(diff[i] / step_size);
       //      std::cout << "bbx " << i << " size: " << diff[i] << " " << steps[i] << " steps\n";
     }
-    
+
     point3d p = pmin;
     NODE* res;
     for (unsigned int x=0; x<steps[0]; ++x) {
@@ -907,7 +907,7 @@ namespace octomap {
 
     if (!parent->hasChildren()) // this is a leaf -> terminate
       return 1;
-    
+
     size_t sum_leafs_children = 0;
     for (unsigned int i=0; i<8; ++i) {
       if (parent->childExists(i)) {

--- a/octomap/include/octomap/OcTreeIterator.hxx
+++ b/octomap/include/octomap/OcTreeIterator.hxx
@@ -166,7 +166,7 @@
         StackElement s;
         s.depth = top.depth +1;
 
-        unsigned short int center_offset_key = tree->tree_max_val >> s.depth;
+        unsigned int center_offset_key = tree->tree_max_val >> s.depth;
         // push on stack in reverse order
         for (int i=7; i>=0; --i) {
           if (top.node->childExists(i)) {
@@ -431,7 +431,7 @@
 
         typename iterator_base::StackElement s;
         s.depth = top.depth +1;
-        unsigned short int center_offset_key = this->tree->tree_max_val >> s.depth;
+        unsigned int center_offset_key = this->tree->tree_max_val >> s.depth;
         // push on stack in reverse order
         for (int i=7; i>=0; --i) {
           if (top.node->childExists(i)) {

--- a/octomap/include/octomap/OcTreeLUT.h
+++ b/octomap/include/octomap/OcTreeLUT.h
@@ -44,21 +44,21 @@ namespace octomap {
 
   //! comparator for keys
   struct equal_keys {
-    bool operator() (const unsigned short int* key1, const unsigned short int* key2) const {
+    bool operator() (const unsigned int* key1, const unsigned int* key2) const {
       return ((key1[0]==key2[0]) && (key1[1] == key2[1]) && (key1[2] == key2[2]));
     }
   };
 
   struct hash_key {
-    unsigned short int operator()(const unsigned short int* key) const {
+    long unsigned int operator()(const unsigned int* key) const {
       return (((31 + key[0]) * 31 + key[1]) * 31 + key[2]);
     }
   };
 
 
-  
+
   /**
-   *   Implements a lookup table that allows to computer keys of neighbor cells directly, 
+   *   Implements a lookup table that allows to computer keys of neighbor cells directly,
    *   see: Samet 1989, "Implementing ray tracing with octrees and neighbor finding"
    */
   class OcTreeLUT {
@@ -82,7 +82,7 @@ namespace octomap {
 
     OcTreeLUT(unsigned int _max_depth);
     ~OcTreeLUT();
-    
+
     bool genNeighborKey(const OcTreeKey& node_key, const signed char& dir,
                         OcTreeKey& neighbor_key) const;
 
@@ -91,7 +91,7 @@ namespace octomap {
     void initLUT();
 
     unsigned int genPos(const OcTreeKey& key, const int& i) const;
-    void changeKey(const int& val, OcTreeKey& key, const unsigned short int& i) const;
+    void changeKey(const int& val, OcTreeKey& key, const unsigned int& i) const;
 
   protected:
 
@@ -100,7 +100,7 @@ namespace octomap {
     signed char nf_values[8][26];
     signed char nf_rec_values[8][26];
     signed char nf_multiple_values[26][4];
-  }; 
+  };
 
 } // namespace
 

--- a/octomap/include/octomap/OccupancyOcTreeBase.h
+++ b/octomap/include/octomap/OccupancyOcTreeBase.h
@@ -54,10 +54,10 @@ namespace octomap {
    * Each class used as NODE type needs to be derived from
    * OccupancyOcTreeNode.
    *
-   * This tree implementation has a maximum depth of 16. 
+   * This tree implementation has a maximum depth of 16.
    * At a resolution of 1 cm, values have to be < +/- 327.68 meters (2^15)
    *
-   * This limitation enables the use of an efficient key generation 
+   * This limitation enables the use of an efficient key generation
    * method which uses the binary representation of the data.
    *
    * \note The tree does not save individual points.
@@ -71,6 +71,11 @@ namespace octomap {
   public:
     /// Default constructor, sets resolution of leafs
     OccupancyOcTreeBase(double resolution);
+
+    /// Constructor to enable derived classes to change tree constants.
+    /// This usually requires a re-implementation of some core tree-traversal functions as well!
+    OccupancyOcTreeBase(double resolution, unsigned int tree_depth, unsigned int tree_max_val);
+
     virtual ~OccupancyOcTreeBase();
 
     /// Copy constructor
@@ -304,17 +309,17 @@ namespace octomap {
      * @return success of operation
      */
     virtual bool insertRay(const point3d& origin, const point3d& end, double maxrange=-1.0, bool lazy_eval = false);
-    
+
     /**
      * Performs raycasting in 3d, similar to computeRay(). Can be called in parallel e.g. with OpenMP
      * for a speedup.
      *
      * A ray is cast from 'origin' with a given direction, the first non-free
-     * cell is returned in 'end' (as center coordinate). This could also be the 
+     * cell is returned in 'end' (as center coordinate). This could also be the
      * origin node if it is occupied or unknown. castRay() returns true if an occupied node
      * was hit by the raycast. If the raycast returns false you can search() the node at 'end' and
      * see whether it's unknown space.
-     * 
+     *
      *
      * @param[in] origin starting coordinate of ray
      * @param[in] direction A vector pointing in the direction of the raycast (NOT a point in space). Does not need to be normalized.
@@ -329,7 +334,7 @@ namespace octomap {
     /**
      * Retrieves the entry point of a ray into a voxel. This is the closest intersection point of the ray
      * originating from origin and a plane of the axis aligned cube.
-     * 
+     *
      * @param[in] origin Starting point of ray
      * @param[in] direction A vector pointing in the direction of the raycast. Does not need to be normalized.
      * @param[in] center The center of the voxel where the ray terminated. This is the output of castRay.
@@ -340,18 +345,18 @@ namespace octomap {
     virtual bool getRayIntersection(const point3d& origin, const point3d& direction, const point3d& center,
                  point3d& intersection, double delta=0.0) const;
 
-		/**
-		 * Performs a step of the marching cubes surface reconstruction algorithm
-		 * to retreive the normal of the triangles that fall in the cube
-		 * formed by the voxels located at the vertex of a given voxel.
-		 *
-		 * @param[in] voxel for which retreive the normals
-		 * @param[out] triangles normals
-		 * @param[in] unknownStatus consider unknown cells as free (false) or occupied (default, true).
-		 * @return True if the input voxel is known in the occupancy grid, and false if it is unknown.
-		 */
-		bool getNormals(const point3d& point, std::vector<point3d>& normals, bool unknownStatus=true) const;
-	
+        /**
+         * Performs a step of the marching cubes surface reconstruction algorithm
+         * to retreive the normal of the triangles that fall in the cube
+         * formed by the voxels located at the vertex of a given voxel.
+         *
+         * @param[in] voxel for which retreive the normals
+         * @param[out] triangles normals
+         * @param[in] unknownStatus consider unknown cells as free (false) or occupied (default, true).
+         * @return True if the input voxel is known in the occupancy grid, and false if it is unknown.
+         */
+        bool getNormals(const point3d& point, std::vector<point3d>& normals, bool unknownStatus=true) const;
+
     //-- set BBX limit (limits tree updates to this bounding box)
 
     ///  use or ignore BBX limit (default: ignore)
@@ -487,9 +492,6 @@ namespace octomap {
     virtual void nodeToMaxLikelihood(NODE& occupancyNode) const;
 
   protected:
-    /// Constructor to enable derived classes to change tree constants.
-    /// This usually requires a re-implementation of some core tree-traversal functions as well!
-    OccupancyOcTreeBase(double resolution, unsigned int tree_depth, unsigned int tree_max_val);
 
     /**
      * Traces a ray from origin to end and updates all voxels on the
@@ -502,12 +504,12 @@ namespace octomap {
 
     NODE* updateNodeRecurs(NODE* node, bool node_just_created, const OcTreeKey& key,
                            unsigned int depth, const float& log_odds_update, bool lazy_eval = false);
-    
+
     NODE* setNodeValueRecurs(NODE* node, bool node_just_created, const OcTreeKey& key,
                            unsigned int depth, const float& log_odds_value, bool lazy_eval = false);
 
     void updateInnerOccupancyRecurs(NODE* node, unsigned int depth);
-    
+
     void toMaxLikelihoodRecurs(NODE* node, unsigned int depth, unsigned int max_depth);
 
 
@@ -521,7 +523,7 @@ namespace octomap {
     bool use_change_detection;
     /// Set of leaf keys (lowest level) which changed since last resetChangeDetection
     KeyBoolMap changed_keys;
-    
+
 
   };
 

--- a/octomap/src/CountingOcTree.cpp
+++ b/octomap/src/CountingOcTree.cpp
@@ -125,7 +125,7 @@ namespace octomap {
 
     if (depth < max_depth && node->hasChildren()) {
 
-      unsigned short int center_offset_key = this->tree_max_val >> (depth + 1);
+      unsigned int center_offset_key = this->tree_max_val >> (depth + 1);
       OcTreeKey search_key;
 
       for (unsigned int i=0; i<8; ++i) {

--- a/octomap/src/OcTreeLUT.cpp
+++ b/octomap/src/OcTreeLUT.cpp
@@ -534,7 +534,7 @@ namespace octomap {
   /*
    * used internally to generate neighbor key from a given key
    */
-  void OcTreeLUT::changeKey(const int& val, OcTreeKey& key, const unsigned short int& i) const {
+  void OcTreeLUT::changeKey(const int& val, OcTreeKey& key, const unsigned int& i) const {
     switch (val) {
     case 0:
       key.k[0] &= ~(1 << i);
@@ -582,14 +582,14 @@ namespace octomap {
 
   bool OcTreeLUT::genNeighborKey(const OcTreeKey& node_key, const signed char& dir,
                                  OcTreeKey& neighbor_key) const {
-    
+
     neighbor_key.k[0] = node_key.k[0];
     neighbor_key.k[1] = node_key.k[1];
     neighbor_key.k[2] = node_key.k[2];
 
     unsigned int depth = 0;
     signed char curDir = dir;
-    
+
     signed char pos;
     while (depth < max_depth) {
       pos = static_cast<signed char>(genPos(neighbor_key, depth));
@@ -598,8 +598,8 @@ namespace octomap {
       if (nf_rec_values[pos][curDir] != LUT_NO_REC) { // recurs
         curDir -= nf_rec_values[pos][curDir];
         depth++;
-      } 
-      else { 
+      }
+      else {
         return true;
       }
     }


### PR DESCRIPTION
The depth of an octree was limited to be exactly 16, so that the space
that could be mapped was limited in size by 2^16*resolution meter, eg
to approx. 6000m at a resolution of 0.1m. To enable larger tree dephts
some OcTreeKey related stuff needed to be changed:

a) Change all short int to unsigned int

And, at some places where such a change occured, unsigned int to long int.
Also changed some constants for 2^16 to 2^32. Utlimately, std::uint8_t et
al should be used.

b) Add a tricky hash function for 32bit based OcTreeKey

OcTreeKey consists of 3 32bit unsigned integers, but a hash function that
is to be used with the C++ std library needs to return a 64bit std::size_t
as a hash value. So we can't generate unique hash keys for every node
anymore. The solution is to only use the lower 16bit of every OcTreeKey-
component, so the resulting 3x16=48bit perfectly fit into std::size_t. This
is only possible as the hash function is never used for all the tree, but
only for the current point cloud. Points will only differ in their last
bits, probably, so the hash values generated for all points of one point
cloud should be unique again.
