### PR TITLE
Command line param for the initial tree depth cutoff

### DIFF
--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -51,7 +51,7 @@ namespace octomap {
     Q_OBJECT
    
   public:
-    ViewerGui(const std::string& filename="", QWidget *parent = 0);
+    ViewerGui(const std::string& filename="", unsigned int initTreeDepth = 16, QWidget *parent = 0);
     ~ViewerGui();
 
     static const unsigned int LASERTYPE_URG  = 0;

--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -51,7 +51,7 @@ namespace octomap {
     Q_OBJECT
    
   public:
-    ViewerGui(const std::string& filename="", unsigned int initTreeDepth = 16, QWidget *parent = 0);
+    ViewerGui(const std::string& filename="", QWidget *parent = 0, unsigned int initTreeDepth = 16);
     ~ViewerGui();
 
     static const unsigned int LASERTYPE_URG  = 0;

--- a/octovis/include/octovis/ViewerSettingsPanel.h
+++ b/octovis/include/octovis/ViewerSettingsPanel.h
@@ -43,13 +43,13 @@ public slots:
     void setNumberOfScans(unsigned scans);
     void setCurrentScan(unsigned scan);
     void setResolution(double resolution);
+    void setTreeDepth(int depth);
 
 private slots:
     void on_firstScanButton_clicked();
     void on_lastScanButton_clicked();
     void on_nextScanButton_clicked();
     void on_fastFwdScanButton_clicked();
-    void setTreeDepth(int depth);
 
 signals:
   void treeDepthChanged(int depth);

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -36,12 +36,13 @@
 
 namespace octomap{
 
-ViewerGui::ViewerGui(const std::string& filename, QWidget *parent)
+ViewerGui::ViewerGui(const std::string& filename, unsigned int initDepth, QWidget *parent)
 : QMainWindow(parent), m_scanGraph(NULL),
   m_trajectoryDrawer(NULL), m_pointcloudDrawer(NULL),
   m_cameraFollowMode(NULL),
   m_octreeResolution(0.1), m_laserMaxRange(-1.), m_occupancyThresh(0.5),
-  m_max_tree_depth(16), m_laserType(LASERTYPE_SICK),
+  m_max_tree_depth(initDepth > 0 && initDepth <= 16 ? initDepth : 16), 
+  m_laserType(LASERTYPE_SICK),
   m_cameraStored(false), m_filename("") {
 
   ui.setupUi(this);
@@ -50,6 +51,7 @@ ViewerGui::ViewerGui(const std::string& filename, QWidget *parent)
 
   // Settings panel at the right side
   ViewerSettingsPanel* settingsPanel = new ViewerSettingsPanel(this);
+  settingsPanel->setTreeDepth(initDepth);
   QDockWidget* settingsDock = new QDockWidget("Octree / Scan graph settings", this);
   settingsDock->setWidget(settingsPanel);
   this->addDockWidget(Qt::RightDockWidgetArea, settingsDock);
@@ -393,6 +395,7 @@ void ViewerGui::openFile(){
 
     QString temp = QString(m_filename.c_str());
     QFileInfo fileinfo(temp);
+    this->setWindowTitle(fileinfo.fileName());
     if (fileinfo.suffix() == "graph"){
       openGraph();
     }else if (fileinfo.suffix() == "bt"){

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -36,7 +36,7 @@
 
 namespace octomap{
 
-ViewerGui::ViewerGui(const std::string& filename, unsigned int initDepth, QWidget *parent)
+ViewerGui::ViewerGui(const std::string& filename, QWidget *parent, unsigned int initDepth)
 : QMainWindow(parent), m_scanGraph(NULL),
   m_trajectoryDrawer(NULL), m_pointcloudDrawer(NULL),
   m_cameraFollowMode(NULL),

--- a/octovis/src/ViewerSettingsPanel.cpp
+++ b/octovis/src/ViewerSettingsPanel.cpp
@@ -114,6 +114,8 @@ void ViewerSettingsPanel::setResolution(double resolution){
 void ViewerSettingsPanel::setTreeDepth(int depth){
   emit treeDepthChanged(depth);
   m_treeDepth = depth;
+  ui.treeDepth->setValue(depth);
+  ui.treeDepthSlider->setValue(depth);
   leafSizeChanged();
 }
 

--- a/octovis/src/main.cpp
+++ b/octovis/src/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 
   QApplication app(argc, argv);
 
-  octomap::ViewerGui gui(filename, depth);
+  octomap::ViewerGui gui(filename, NULL, depth);
   gui.show(); 
   return app.exec();
 }

--- a/octovis/src/main.cpp
+++ b/octovis/src/main.cpp
@@ -25,17 +25,22 @@
 #include <QtGui>
 #include <QApplication>
 #include <octovis/ViewerGui.h>
+#include <stdlib.h> //strtol
 
 int main(int argc, char *argv[]) {
 
   std::string filename = "";
-  if (argc == 2) {
-    filename = std::string(argv[1]);
+  int depth = 0;
+  if (argc == 1) { 
+    std::cout << "Usage: " << argv[0] << " [mapfile] [tree depth cutoff]\n"; 
+    std::cout << "Where the optional [tree depth cutoff] is an integer from 1 to 16\n"; 
   }
+  if (argc >= 2) { filename = std::string(argv[1]); }
+  if (argc >= 3) { depth = std::strtol(argv[2], NULL, 10); }//zero on parse error
 
   QApplication app(argc, argv);
 
-  octomap::ViewerGui gui(filename);
+  octomap::ViewerGui gui(filename, depth);
   gui.show(); 
   return app.exec();
 }


### PR DESCRIPTION
Just a convenience commit for octovis:
My laptop is too slow to display big maps smoothly.
So on startup I like to have a coarser view, move the map in a desired 
position and then increase the cutoff to view that perspective in detail,
make screenshots and whatsoever.

Also shows a short usage message if started without parameters.