### PR TITLE
use static_cast in KeyHash

### DIFF
--- a/octomap/include/octomap/OcTreeKey.h
+++ b/octomap/include/octomap/OcTreeKey.h
@@ -113,7 +113,9 @@ namespace octomap {
         // a simple hashing function 
 	// explicit casts to size_t to operate on the complete range
 	// constanst will be promoted according to C++ standard
-        return size_t(key.k[0]) + 1447*size_t(key.k[1]) + 345637*size_t(key.k[2]);
+        return static_cast<size_t>(key.k[0])
+          + 1447*static_cast<size_t>(key.k[1])
+          + 345637*static_cast<size_t>(key.k[2]);
       }
     };
     


### PR DESCRIPTION
I am using a std::map keyed on OcTreeKeys to represent a costmap over Octomap nodes. It uses a Compare object that uses `OcTreeKey::KeyHash`. When debugging a program with Clang Undefined Behavior Sanitizer, I got the following error.

```
/usr/include/octomap/OcTreeKey.h:100:49: runtime error: signed integer overflow: 345637 * 32767 cannot be represented in type 'int'
```

It seems that the cast to size_t in this function doesn't quite work. Using C++-style `static_cast` fixes the issue. I believe that `(size_t) key.k[0]` would also work, but `static_cast` will give compile-type checking ability.