### PR TITLE
Alternative rendering

### DIFF
--- a/octovis/include/octovis/OcTreeDrawer.h
+++ b/octovis/include/octovis/OcTreeDrawer.h
@@ -59,16 +59,17 @@ namespace octomap {
 
     /// sets alpha level for occupied cells
     void setAlphaOccupied(double alpha);
+    void setAlternativeDrawing(bool flag){m_alternativeDrawing = flag;}
 
     void enableOcTree(bool enabled = true);
-    void enableOcTreeCells(bool enabled = true) {m_drawOccupied = enabled; };
-    void enableFreespace(bool enabled = true) {m_drawFree = enabled; };
-    void enableSelection(bool enabled = true) {m_drawSelection = enabled; };
-    void setMax_tree_depth(unsigned int max_tree_depth) {m_max_tree_depth = max_tree_depth;};
+    void enableOcTreeCells(bool enabled = true) { m_update = true; m_drawOccupied = enabled; };
+    void enableFreespace(bool enabled = true) { m_update = true; m_drawFree = enabled; };
+    void enableSelection(bool enabled = true) { m_update = true; m_drawSelection = enabled; };
+    void setMax_tree_depth(unsigned int max_tree_depth) { m_update = true; m_max_tree_depth = max_tree_depth;};
 
     // set new origin (move object)
     void setOrigin(octomap::pose6d t);
-    void enableAxes(bool enabled = true) { m_displayAxes = enabled; };
+    void enableAxes(bool enabled = true) { m_update = true; m_displayAxes = enabled; };
 
   protected:
     //void clearOcTree();
@@ -146,6 +147,8 @@ namespace octomap {
     bool m_drawSelection;
     bool m_octree_grid_vis_initialized;
     bool m_displayAxes;
+    bool m_alternativeDrawing;
+    mutable bool m_update;
 
     unsigned int m_max_tree_depth;
     double m_alphaOccupied;

--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -51,7 +51,7 @@ namespace octomap {
     Q_OBJECT
    
   public:
-    ViewerGui(const std::string& filename="", QWidget *parent = 0);
+    ViewerGui(const std::string& filename="", unsigned int initTreeDepth = 16, QWidget *parent = 0);
     ~ViewerGui();
 
     static const unsigned int LASERTYPE_URG  = 0;

--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -51,7 +51,7 @@ namespace octomap {
     Q_OBJECT
    
   public:
-    ViewerGui(const std::string& filename="", unsigned int initTreeDepth = 16, QWidget *parent = 0);
+    ViewerGui(const std::string& filename="", QWidget *parent = 0, unsigned int initTreeDepth = 16);
     ~ViewerGui();
 
     static const unsigned int LASERTYPE_URG  = 0;

--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -106,6 +106,7 @@ namespace octomap {
     void on_actionSelected_toggled(bool enabled);
     void on_actionAxes_toggled(bool checked);
     void on_actionHideBackground_toggled(bool checked);
+    void on_actionAlternateRendering_toggled(bool checked);
     void on_actionClear_triggered();
 
     void on_action_bg_black_triggered();

--- a/octovis/include/octovis/ViewerGui.ui
+++ b/octovis/include/octovis/ViewerGui.ui
@@ -76,6 +76,8 @@
     <addaction name="actionAxes"/>
     <addaction name="actionHideBackground"/>
     <addaction name="separator"/>
+    <addaction name="actionAlternateRendering"/>
+    <addaction name="separator"/>
     <addaction name="actionReset_view"/>
     <addaction name="actionStore_camera"/>
     <addaction name="actionRestore_camera"/>
@@ -245,6 +247,14 @@
    </property>
    <property name="shortcut">
     <string>0</string>
+   </property>
+  </action>
+  <action name="actionSwitchRenderMode">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Alternative rendering</string>
    </property>
   </action>
   <action name="actionClear">
@@ -539,6 +549,17 @@
    </property>
    <property name="text">
      <string>With &quot;occupied&quot; (only unknown)</string>
+   </property>
+  </action>
+  <action name="actionAlternateRendering">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Alternate Rendering</string>
+   </property>
+   <property name="toolTip">
+    <string>Uses precompiled rendering of the octomap. Faster and requires less CPU but more memory on your graphics card. The first rendering takes longer.</string>
    </property>
   </action>
  </widget>

--- a/octovis/include/octovis/ViewerSettingsPanel.h
+++ b/octovis/include/octovis/ViewerSettingsPanel.h
@@ -43,13 +43,13 @@ public slots:
     void setNumberOfScans(unsigned scans);
     void setCurrentScan(unsigned scan);
     void setResolution(double resolution);
+    void setTreeDepth(int depth);
 
 private slots:
     void on_firstScanButton_clicked();
     void on_lastScanButton_clicked();
     void on_nextScanButton_clicked();
     void on_fastFwdScanButton_clicked();
-    void setTreeDepth(int depth);
 
 signals:
   void treeDepthChanged(int depth);

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -36,12 +36,13 @@
 
 namespace octomap{
 
-ViewerGui::ViewerGui(const std::string& filename, QWidget *parent)
+ViewerGui::ViewerGui(const std::string& filename, unsigned int initDepth, QWidget *parent)
 : QMainWindow(parent), m_scanGraph(NULL),
   m_trajectoryDrawer(NULL), m_pointcloudDrawer(NULL),
   m_cameraFollowMode(NULL),
   m_octreeResolution(0.1), m_laserMaxRange(-1.), m_occupancyThresh(0.5),
-  m_max_tree_depth(16), m_laserType(LASERTYPE_SICK),
+  m_max_tree_depth(initDepth > 0 && initDepth <= 16 ? initDepth : 16), 
+  m_laserType(LASERTYPE_SICK),
   m_cameraStored(false), m_filename("") {
 
   ui.setupUi(this);
@@ -50,6 +51,7 @@ ViewerGui::ViewerGui(const std::string& filename, QWidget *parent)
 
   // Settings panel at the right side
   ViewerSettingsPanel* settingsPanel = new ViewerSettingsPanel(this);
+  settingsPanel->setTreeDepth(initDepth);
   QDockWidget* settingsDock = new QDockWidget("Octree / Scan graph settings", this);
   settingsDock->setWidget(settingsPanel);
   this->addDockWidget(Qt::RightDockWidgetArea, settingsDock);
@@ -393,6 +395,7 @@ void ViewerGui::openFile(){
 
     QString temp = QString(m_filename.c_str());
     QFileInfo fileinfo(temp);
+    this->setWindowTitle(fileinfo.fileName());
     if (fileinfo.suffix() == "graph"){
       openGraph();
     }else if (fileinfo.suffix() == "bt"){

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -43,7 +43,9 @@ ViewerGui::ViewerGui(const std::string& filename, QWidget *parent, unsigned int 
   m_octreeResolution(0.1), m_laserMaxRange(-1.), m_occupancyThresh(0.5),
   m_max_tree_depth(initDepth > 0 && initDepth <= 16 ? initDepth : 16), 
   m_laserType(LASERTYPE_SICK),
-  m_cameraStored(false), m_filename("") {
+  m_cameraStored(false),
+  m_filename("") 
+{
 
   ui.setupUi(this);
   m_glwidget = new ViewerWidget(this);
@@ -1045,6 +1047,13 @@ void ViewerGui::on_actionHideBackground_toggled(bool checked) {
     if (checked) m_glwidget->removeSceneObject(r->octree_drawer);
     else         m_glwidget->addSceneObject(r->octree_drawer);
     m_glwidget->updateGL();
+  }
+}
+
+void ViewerGui::on_actionAlternateRendering_toggled(bool checked) {
+  for (std::map<int, OcTreeRecord>::iterator it = m_octrees.begin(); it != m_octrees.end(); ++it) {
+    //std::cout << "Setting Octree " << it->first << " to " << (checked ? "alternate" : "regular") << " rendering.";
+    it->second.octree_drawer->setAlternativeDrawing(checked);
   }
 }
 

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -36,7 +36,7 @@
 
 namespace octomap{
 
-ViewerGui::ViewerGui(const std::string& filename, unsigned int initDepth, QWidget *parent)
+ViewerGui::ViewerGui(const std::string& filename, QWidget *parent, unsigned int initDepth)
 : QMainWindow(parent), m_scanGraph(NULL),
   m_trajectoryDrawer(NULL), m_pointcloudDrawer(NULL),
   m_cameraFollowMode(NULL),

--- a/octovis/src/ViewerSettingsPanel.cpp
+++ b/octovis/src/ViewerSettingsPanel.cpp
@@ -114,6 +114,8 @@ void ViewerSettingsPanel::setResolution(double resolution){
 void ViewerSettingsPanel::setTreeDepth(int depth){
   emit treeDepthChanged(depth);
   m_treeDepth = depth;
+  ui.treeDepth->setValue(depth);
+  ui.treeDepthSlider->setValue(depth);
   leafSizeChanged();
 }
 

--- a/octovis/src/main.cpp
+++ b/octovis/src/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 
   QApplication app(argc, argv);
 
-  octomap::ViewerGui gui(filename, depth);
+  octomap::ViewerGui gui(filename, NULL, depth);
   gui.show(); 
   return app.exec();
 }

--- a/octovis/src/main.cpp
+++ b/octovis/src/main.cpp
@@ -25,17 +25,22 @@
 #include <QtGui>
 #include <QApplication>
 #include <octovis/ViewerGui.h>
+#include <stdlib.h> //strtol
 
 int main(int argc, char *argv[]) {
 
   std::string filename = "";
-  if (argc == 2) {
-    filename = std::string(argv[1]);
+  int depth = 0;
+  if (argc == 1) { 
+    std::cout << "Usage: " << argv[0] << " [mapfile] [tree depth cutoff]\n"; 
+    std::cout << "Where the optional [tree depth cutoff] is an integer from 1 to 16\n"; 
   }
+  if (argc >= 2) { filename = std::string(argv[1]); }
+  if (argc >= 3) { depth = std::strtol(argv[2], NULL, 10); }//zero on parse error
 
   QApplication app(argc, argv);
 
-  octomap::ViewerGui gui(filename);
+  octomap::ViewerGui gui(filename, depth);
   gui.show(); 
   return app.exec();
 }


### PR DESCRIPTION
See the commit message for a detailed description.

The following screenshots show the exact effect on CPU, RAM (see the output of "top" on the upper left) and FPS (shown within the octovis window on the upper left, below "File" in Hz) on my machine (using Intel Corporation Broadwell-U Integrated Graphics). I would guess that the effect would be even more pronounced with better graphics cards, as the rendering bottleneck is moved from the CPU to the GPU.

Regular rendering
![octovis-16-regular](https://cloud.githubusercontent.com/assets/6112784/18717840/a53d2db6-8021-11e6-8e2d-11f7549eac39.jpg)

Rendering with the new method of this pull request
![octovis-16-alternate](https://cloud.githubusercontent.com/assets/6112784/18717843/a7a462ae-8021-11e6-9400-322c3d6204b0.jpg)
