### PR TITLE
Add version information to *-config.cmake files

### DIFF
--- a/dynamicEDT3D/dynamicEDT3DConfig.cmake.in
+++ b/dynamicEDT3D/dynamicEDT3DConfig.cmake.in
@@ -8,11 +8,20 @@
 #    TARGET_LINK_LIBRARIES(MY_TARGET_NAME ${DYNAMICEDT3D_LIBRARIES})
 #
 # It defines the following variables
-#  DYNAMICEDT3D_INCLUDE_DIRS - include directories for dynamicEDT3D
-#  DYNAMICEDT3D_LIBRARY_DIRS - library directories for dynamicEDT3D (normally not used!)
-#  DYNAMICEDT3D_LIBRARIES    - libraries to link against
+#  DYNAMICEDT3D_INCLUDE_DIRS  - include directories for dynamicEDT3D
+#  DYNAMICEDT3D_LIBRARY_DIRS  - library directories for dynamicEDT3D (normally not used!)
+#  DYNAMICEDT3D_LIBRARIES     - libraries to link against
+#  DYNAMICEDT3D_MAJOR_VERSION - major version
+#  DYNAMICEDT3D_MINOR_VERSION - minor version
+#  DYNAMICEDT3D_PATCH_VERSION - patch version
+#  DYNAMICEDT3D_VERSION       - major.minor.patch version
 
 @PACKAGE_INIT@
+
+set(DYNAMICEDT3D_MAJOR_VERSION "@DYNAMICEDT3D_MAJOR_VERSION@")
+set(DYNAMICEDT3D_MINOR_VERSION "@DYNAMICEDT3D_MINOR_VERSION@")
+set(DYNAMICEDT3D_PATCH_VERSION "@DYNAMICEDT3D_PATCH_VERSION@")
+set(DYNAMICEDT3D_VERSION "@DYNAMICEDT3D_VERSION@")
 
 # Tell the user project where to find our headers and libraries
 set_and_check(DYNAMICEDT3D_INCLUDE_DIRS "@PACKAGE_DYNAMICEDT3D_INCLUDE_DIRS@")

--- a/octomap/octomap-config.cmake.in
+++ b/octomap/octomap-config.cmake.in
@@ -16,17 +16,25 @@
 #      - OCTOMAP_LIBRARY_DIRS   : The directory where lib files are. Calling
 #                                 LINK_DIRECTORIES with this path is NOT needed.
 #      - OCTOMAP_INCLUDE_DIRS   : The OctoMap include directories.
+#      - OCTOMAP_MAJOR_VERSION  : Major version.
+#      - OCTOMAP_MINOR_VERSION  : Minor version.
+#      - OCTOMAP_PATCH_VERSION  : Patch version.
+#      - OCTOMAP_VERSION        : Major.Minor.Patch version.
 #
 # ===================================================================================
 
 @PACKAGE_INIT@
 
+set(OCTOMAP_MAJOR_VERSION "@OCTOMAP_MAJOR_VERSION@")
+set(OCTOMAP_MINOR_VERSION "@OCTOMAP_MINOR_VERSION@")
+set(OCTOMAP_PATCH_VERSION "@OCTOMAP_PATCH_VERSION@")
+set(OCTOMAP_VERSION "@OCTOMAP_VERSION@")
+
 set_and_check(OCTOMAP_INCLUDE_DIRS "@PACKAGE_OCTOMAP_INCLUDE_DIRS@")
 set_and_check(OCTOMAP_LIBRARY_DIRS "@PACKAGE_OCTOMAP_LIB_DIR@")
- 
 
 # Set library names
-set(OCTOMAP_LIBRARIES 
+set(OCTOMAP_LIBRARIES
   "@PACKAGE_OCTOMAP_LIB_DIR@/@OCTOMAP_LIBRARY@"
   "@PACKAGE_OCTOMAP_LIB_DIR@/@OCTOMATH_LIBRARY@"
 )

--- a/octovis/octovis-config.cmake.in
+++ b/octovis/octovis-config.cmake.in
@@ -1,13 +1,21 @@
 # It defines the following variables
-#  OCTOVIS_INCLUDE_DIRS - include directories for OctoMap viewer
-#  OCTOVIS_LIBRARY_DIRS - library directories for OctoMap viewer 
-#  OCTOVIS_LIBRARIES    - libraries to link against
- 
+#  OCTOVIS_INCLUDE_DIRS  - include directories for OctoMap viewer
+#  OCTOVIS_LIBRARY_DIRS  - library directories for OctoMap viewer
+#  OCTOVIS_LIBRARIES     - libraries to link against
+#  OCTOVIS_MAJOR_VERSION - major version
+#  OCTOVIS_MINOR_VERSION - minor version
+#  OCTOVIS_PATCH_VERSION - patch version
+#  OCTOVIS_VERSION       - major.minor.patch version
+
 @PACKAGE_INIT@
+
+set(OCTOVIS_MAJOR_VERSION "@OCTOVIS_MAJOR_VERSION@")
+set(OCTOVIS_MINOR_VERSION "@OCTOVIS_MINOR_VERSION@")
+set(OCTOVIS_PATCH_VERSION "@OCTOVIS_PATCH_VERSION@")
+set(OCTOVIS_VERSION "@OCTOVIS_VERSION@")
 
 set_and_check(OCTOVIS_INCLUDE_DIRS "@PACKAGE_OCTOVIS_INCLUDE_DIRS@" "@QGLViewer_INCLUDE_DIR@")
 set_and_check(OCTOVIS_LIBRARY_DIRS "@PACKAGE_OCTOVIS_LIB_DIR@" "@QGLViewer_LIBRARY_DIR@")
-
 
 # Set library names as absolute paths:
 set(OCTOVIS_LIBRARIES


### PR DESCRIPTION
The presence of `*-config-version.cmake` files not withstanding, it is common to include version information in `*-config.cmake` files for ease of use by downstream projects.