### PR TITLE
Add alternative rendering method

### DIFF
--- a/octovis/include/octovis/OcTreeDrawer.h
+++ b/octovis/include/octovis/OcTreeDrawer.h
@@ -59,16 +59,17 @@ namespace octomap {
 
     /// sets alpha level for occupied cells
     void setAlphaOccupied(double alpha);
+    void setAlternativeDrawing(bool flag){m_alternativeDrawing = flag;}
 
     void enableOcTree(bool enabled = true);
-    void enableOcTreeCells(bool enabled = true) {m_drawOccupied = enabled; };
-    void enableFreespace(bool enabled = true) {m_drawFree = enabled; };
-    void enableSelection(bool enabled = true) {m_drawSelection = enabled; };
-    void setMax_tree_depth(unsigned int max_tree_depth) {m_max_tree_depth = max_tree_depth;};
+    void enableOcTreeCells(bool enabled = true) { m_update = true; m_drawOccupied = enabled; };
+    void enableFreespace(bool enabled = true) { m_update = true; m_drawFree = enabled; };
+    void enableSelection(bool enabled = true) { m_update = true; m_drawSelection = enabled; };
+    void setMax_tree_depth(unsigned int max_tree_depth) { m_update = true; m_max_tree_depth = max_tree_depth;};
 
     // set new origin (move object)
     void setOrigin(octomap::pose6d t);
-    void enableAxes(bool enabled = true) { m_displayAxes = enabled; };
+    void enableAxes(bool enabled = true) { m_update = true; m_displayAxes = enabled; };
 
   protected:
     //void clearOcTree();
@@ -146,6 +147,8 @@ namespace octomap {
     bool m_drawSelection;
     bool m_octree_grid_vis_initialized;
     bool m_displayAxes;
+    bool m_alternativeDrawing;
+    mutable bool m_update;
 
     unsigned int m_max_tree_depth;
     double m_alphaOccupied;

--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -106,6 +106,7 @@ namespace octomap {
     void on_actionSelected_toggled(bool enabled);
     void on_actionAxes_toggled(bool checked);
     void on_actionHideBackground_toggled(bool checked);
+    void on_actionAlternateRendering_toggled(bool checked);
     void on_actionClear_triggered();
 
     void on_action_bg_black_triggered();

--- a/octovis/include/octovis/ViewerGui.ui
+++ b/octovis/include/octovis/ViewerGui.ui
@@ -76,6 +76,8 @@
     <addaction name="actionAxes"/>
     <addaction name="actionHideBackground"/>
     <addaction name="separator"/>
+    <addaction name="actionAlternateRendering"/>
+    <addaction name="separator"/>
     <addaction name="actionReset_view"/>
     <addaction name="actionStore_camera"/>
     <addaction name="actionRestore_camera"/>
@@ -245,6 +247,14 @@
    </property>
    <property name="shortcut">
     <string>0</string>
+   </property>
+  </action>
+  <action name="actionSwitchRenderMode">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Alternative rendering</string>
    </property>
   </action>
   <action name="actionClear">
@@ -539,6 +549,17 @@
    </property>
    <property name="text">
      <string>With &quot;occupied&quot; (only unknown)</string>
+   </property>
+  </action>
+  <action name="actionAlternateRendering">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Alternate Rendering</string>
+   </property>
+   <property name="toolTip">
+    <string>Uses precompiled rendering of the octomap. Faster and requires less CPU but more memory on your graphics card. The first rendering takes longer.</string>
    </property>
   </action>
  </widget>

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -43,7 +43,9 @@ ViewerGui::ViewerGui(const std::string& filename, QWidget *parent, unsigned int 
   m_octreeResolution(0.1), m_laserMaxRange(-1.), m_occupancyThresh(0.5),
   m_max_tree_depth(initDepth > 0 && initDepth <= 16 ? initDepth : 16), 
   m_laserType(LASERTYPE_SICK),
-  m_cameraStored(false), m_filename("") {
+  m_cameraStored(false),
+  m_filename("") 
+{
 
   ui.setupUi(this);
   m_glwidget = new ViewerWidget(this);
@@ -1045,6 +1047,13 @@ void ViewerGui::on_actionHideBackground_toggled(bool checked) {
     if (checked) m_glwidget->removeSceneObject(r->octree_drawer);
     else         m_glwidget->addSceneObject(r->octree_drawer);
     m_glwidget->updateGL();
+  }
+}
+
+void ViewerGui::on_actionAlternateRendering_toggled(bool checked) {
+  for (std::map<int, OcTreeRecord>::iterator it = m_octrees.begin(); it != m_octrees.end(); ++it) {
+    //std::cout << "Setting Octree " << it->first << " to " << (checked ? "alternate" : "regular") << " rendering.";
+    it->second.octree_drawer->setAlternativeDrawing(checked);
   }
 }
 


### PR DESCRIPTION
Replacement for PR #136. See extended description there.

By using opengl compiled display lists for rendering
the cubes, CPU and RAM usage and CPU-GPU communication
can be strongly reduced, leading to 3-4x higher frame
rates at half the CPU and RAM usage.

The drawbacks are long "compilation" times before the
first rendering and upon all changes in the octree
display, like selecting a new colormap or depth cutoff
(but not on changing the perspective of course).

Further, for displaying too detailed maps octovis may crash,
supposably due to exhaustion of the RAM on the graphics card.

Therefore the feature is off by default, but can be enabled
by checking View->"Alternate Rendering"