### PR TITLE
Make octomap-config.cmake.in cross-compilation proof

### DIFF
--- a/octomap/octomap-config.cmake.in
+++ b/octomap/octomap-config.cmake.in
@@ -13,8 +13,6 @@
 #
 #    This file will define the following variables:
 #      - OCTOMAP_LIBRARIES      : The list of libraries to links against.
-#      - OCTOMAP_LIBRARY_DIRS   : The directory where lib files are. Calling
-#                                 LINK_DIRECTORIES with this path is NOT needed.
 #      - OCTOMAP_INCLUDE_DIRS   : The OctoMap include directories.
 #      - OCTOMAP_MAJOR_VERSION  : Major version.
 #      - OCTOMAP_MINOR_VERSION  : Minor version.
@@ -31,12 +29,18 @@ set(OCTOMAP_PATCH_VERSION "@OCTOMAP_PATCH_VERSION@")
 set(OCTOMAP_VERSION "@OCTOMAP_VERSION@")
 
 set_and_check(OCTOMAP_INCLUDE_DIRS "@PACKAGE_OCTOMAP_INCLUDE_DIRS@")
-set_and_check(OCTOMAP_LIBRARY_DIRS "@PACKAGE_OCTOMAP_LIB_DIR@")
 
 # Set library names
-set(OCTOMAP_LIBRARIES
-  "@PACKAGE_OCTOMAP_LIB_DIR@/@OCTOMAP_LIBRARY@"
-  "@PACKAGE_OCTOMAP_LIB_DIR@/@OCTOMATH_LIBRARY@"
-)
+foreach(lib octomap;octomath)
+  set(onelib "${lib}-NOTFOUND")
+  find_library(onelib ${lib}
+    PATHS "@OCTOMAP_LIB_DIR@"
+    NO_DEFAULT_PATH
+  )
+  if(NOT onelib)
+    message(FATAL_ERROR "Library '${lib}' in package octomap is not installed properly")
+  endif()
+  list(APPEND OCTOMAP_LIBRARIES ${onelib})
+endforeach()
 
 @OCTOMAP_INCLUDE_TARGETS@


### PR DESCRIPTION
The file octomap-config.cmake.in may be used not only for
on-target compilation, but also in a cross-compilation environment
where the file is placed not under ${CMAKE_INSTALL_PREFIX}, but
under ${SOME_SYSROOT}${CMAKE_INSTALL_PREFIX} like in case of Yocto.

In order to accommodate both cases (when a dependent lib is
cross-compiled first, then gets recompiled on the target device)
it's more reliable not use absolute pathes to the libs in the
config included by dependent source packages. Instead use
CMake's find_library() command like it's been done for packages
like urdfdom.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>