### PR TITLE
Improved build by specifically targeting local includes in case of available system includes

### DIFF
--- a/octovis/CMakeLists.txt
+++ b/octovis/CMakeLists.txt
@@ -48,7 +48,7 @@ ${CMAKE_SOURCE_DIR}/../octomap/lib/cmake/octomap
 )
 MESSAGE(STATUS "Found octomap version: " ${octomap_VERSION})
 
-INCLUDE_DIRECTORIES(${OCTOMAP_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(BEFORE SYSTEM ${OCTOMAP_INCLUDE_DIRS})
 
 # Export the package for use from the build-tree
 # (this registers the build-tree with a global CMake-registry)


### PR DESCRIPTION
I ran into a problem of building octomap from source with a locally installed "ros-kinetic-octovis" package. The compiler was wrongly using the incompatible header installed in my system instead of the header shipped with the sources. My change resolves this issue on my system, thus you might want to take over this small change.