### PR TITLE
a minimal workaround for the register issue

### DIFF
--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -29,6 +29,8 @@
 #include <octovis/ViewerGui.h>
 #include <octovis/ColorOcTreeDrawer.h>
 #include <octomap/MapCollection.h>
+//Dummy object definition to ensure VS2012 does not drop the StaticMemberInitializer, causing this tree failing to register.
+octomap::ColorOcTree colortreeTmp(0);
 
 
 #define _MAXRANGE_URG 5.1


### PR DESCRIPTION
 a minimal workaround for the ColorOcTree type register issue on the visual studio 2012 platform of windows 8
a redundant object definition to ensure VS2012 not to drop the the constructor of the member static class called StaticMemberInitializer, causing the ColorOcTree failing to register.