### PR TITLE
Fix segv of CountingOcTree by checking root == NULL

### DIFF
--- a/octomap/src/CountingOcTree.cpp
+++ b/octomap/src/CountingOcTree.cpp
@@ -65,6 +65,10 @@ namespace octomap {
   // Note: do not inline this method, will decrease speed (KMW)
   CountingOcTreeNode* CountingOcTree::updateNode(const OcTreeKey& k) {
 
+    if (root == NULL) {
+      root = new CountingOcTreeNode();
+      tree_size++;
+    }
     CountingOcTreeNode* curNode (root);
     curNode->increaseCount();
 


### PR DESCRIPTION
This seems a critical bug, and I can't find any code which works with CountingOcTree,
there is no example code.
Checking if root is NULL is necessary, and this PR fixes the issue by creating root node if it does not exist.