### PR TITLE
Fix octomap-static dependency on octomath-static

### DIFF
--- a/octomap/src/CMakeLists.txt
+++ b/octomap/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set_target_properties( octomap PROPERTIES
 )
 ADD_LIBRARY( octomap-static STATIC ${octomap_SRCS})
 SET_TARGET_PROPERTIES(octomap-static PROPERTIES OUTPUT_NAME "octomap") 
+add_dependencies(octomap-static octomath-static)
 
 TARGET_LINK_LIBRARIES(octomap octomath)
 


### PR DESCRIPTION
The title says it all: building `octomap-static` **should** also build its dependency `octomath-static`.

No need to manually call `add_dependencies()` for their shared lib versions because CMake automatically adds the dependency because one is linked against the other.