### PR TITLE
fix all gcc -Wshadow warnings in public headers

### DIFF
--- a/octomap/include/octomap/MapNode.hxx
+++ b/octomap/include/octomap/MapNode.hxx
@@ -38,19 +38,19 @@ namespace octomap {
   }
 
   template <class TREETYPE>
-  MapNode<TREETYPE>::MapNode(TREETYPE* node_map, pose6d origin) {
-  	this->node_map = node_map;
-  	this->origin = origin;
+  MapNode<TREETYPE>::MapNode(TREETYPE* in_node_map, pose6d in_origin) {
+  	this->node_map = in_node_map;
+  	this->origin = in_origin;
   }
 
   template <class TREETYPE>
-  MapNode<TREETYPE>::MapNode(const Pointcloud& cloud, pose6d origin): node_map(0) {
+  MapNode<TREETYPE>::MapNode(const Pointcloud& in_cloud, pose6d in_origin): node_map(0) {
   }
 
   template <class TREETYPE>
-  MapNode<TREETYPE>::MapNode(std::string filename, pose6d origin): node_map(0){
+  MapNode<TREETYPE>::MapNode(std::string filename, pose6d in_origin): node_map(0){
   	readMap(filename);
-  	this->origin = origin;
+  	this->origin = in_origin;
   	id = filename;
   }
 
@@ -58,7 +58,7 @@ namespace octomap {
   MapNode<TREETYPE>::~MapNode() {
   	clear();
   }
-    
+
   template <class TREETYPE>
   void MapNode<TREETYPE>::updateMap(const Pointcloud& cloud, point3d sensor_origin) {
   }

--- a/octomap/include/octomap/OcTreeBaseImpl.hxx
+++ b/octomap/include/octomap/OcTreeBaseImpl.hxx
@@ -43,26 +43,26 @@ namespace octomap {
 
 
   template <class NODE,class I>
-  OcTreeBaseImpl<NODE,I>::OcTreeBaseImpl(double resolution) :
+  OcTreeBaseImpl<NODE,I>::OcTreeBaseImpl(double in_resolution) :
     I(), root(NULL), tree_depth(16), tree_max_val(32768),
-    resolution(resolution), tree_size(0)
+    resolution(in_resolution), tree_size(0)
   {
-    
+
     init();
 
     // no longer create an empty root node - only on demand
   }
 
   template <class NODE,class I>
-  OcTreeBaseImpl<NODE,I>::OcTreeBaseImpl(double resolution, unsigned int tree_depth, unsigned int tree_max_val) :
-    I(), root(NULL), tree_depth(tree_depth), tree_max_val(tree_max_val),
-    resolution(resolution), tree_size(0)
+  OcTreeBaseImpl<NODE,I>::OcTreeBaseImpl(double in_resolution, unsigned int in_tree_depth, unsigned int in_tree_max_val) :
+    I(), root(NULL), tree_depth(in_tree_depth), tree_max_val(in_tree_max_val),
+    resolution(in_resolution), tree_size(0)
   {
     init();
 
     // no longer create an empty root node - only on demand
   }
-  
+
 
   template <class NODE,class I>
   OcTreeBaseImpl<NODE,I>::~OcTreeBaseImpl(){
@@ -157,7 +157,7 @@ namespace octomap {
     resolution = r;
     resolution_factor = 1. / resolution;
 
-    tree_center(0) = tree_center(1) = tree_center(2) 
+    tree_center(0) = tree_center(1) = tree_center(2)
       = (float) (((double) tree_max_val) / resolution_factor);
 
     // init node size lookup table:
@@ -168,7 +168,7 @@ namespace octomap {
 
     size_changed = true;
   }
-  
+
   template <class NODE,class I>
   NODE* OcTreeBaseImpl<NODE,I>::createNodeChild(NODE* node, unsigned int childIdx){
     assert(childIdx < 8);
@@ -178,45 +178,45 @@ namespace octomap {
     assert (node->children[childIdx] == NULL);
     NODE* newNode = new NODE();
     node->children[childIdx] = static_cast<AbstractOcTreeNode*>(newNode);
-    
+
     tree_size++;
     size_changed = true;
-    
+
     return newNode;
   }
-  
+
   template <class NODE,class I>
   void OcTreeBaseImpl<NODE,I>::deleteNodeChild(NODE* node, unsigned int childIdx){
     assert((childIdx < 8) && (node->children != NULL));
     assert(node->children[childIdx] != NULL);
     delete static_cast<NODE*>(node->children[childIdx]); // TODO delete check if empty
     node->children[childIdx] = NULL;
-    
+
     tree_size--;
     size_changed = true;
   }
-  
-  template <class NODE,class I>  
+
+  template <class NODE,class I>
   NODE* OcTreeBaseImpl<NODE,I>::getNodeChild(NODE* node, unsigned int childIdx) const{
     assert((childIdx < 8) && (node->children != NULL));
     assert(node->children[childIdx] != NULL);
     return static_cast<NODE*>(node->children[childIdx]);
   }
-    
+
   template <class NODE,class I>
   const NODE* OcTreeBaseImpl<NODE,I>::getNodeChild(const NODE* node, unsigned int childIdx) const{
     assert((childIdx < 8) && (node->children != NULL));
     assert(node->children[childIdx] != NULL);
     return static_cast<const NODE*>(node->children[childIdx]);
   }
-  
+
   template <class NODE,class I>
   bool OcTreeBaseImpl<NODE,I>::isNodeCollapsible(const NODE* node) const{
     // all children must exist, must not have children of
     // their own and have the same occupancy probability
     if (!nodeChildExists(node, 0))
       return false;
-    
+
     const NODE* firstChild = getNodeChild(node, 0);
     if (nodeHasChildren(firstChild))
       return false;
@@ -227,10 +227,10 @@ namespace octomap {
       if (!nodeChildExists(node, i) || nodeHasChildren(getNodeChild(node, i)) || !(*(getNodeChild(node, i)) == *(firstChild)))
         return false;
     }
-    
+
     return true;
   }
-  
+
   template <class NODE,class I>
   bool OcTreeBaseImpl<NODE,I>::nodeChildExists(const NODE* node, unsigned int childIdx) const{
     assert(childIdx < 8);
@@ -239,12 +239,12 @@ namespace octomap {
     else
       return false;
   }
-  
+
   template <class NODE,class I>
   bool OcTreeBaseImpl<NODE,I>::nodeHasChildren(const NODE* node) const {
     if (node->children == NULL)
       return false;
-    
+
     for (unsigned int i = 0; i<8; i++){
       if (node->children[i] != NULL)
         return true;
@@ -252,20 +252,20 @@ namespace octomap {
     return false;
   }
 
-    
+
   template <class NODE,class I>
   void OcTreeBaseImpl<NODE,I>::expandNode(NODE* node){
     assert(!nodeHasChildren(node));
-    
+
     for (unsigned int k=0; k<8; k++) {
       NODE* newNode = createNodeChild(node, k);
       newNode->copyData(*node);
     }
   }
-  
+
   template <class NODE,class I>
   bool OcTreeBaseImpl<NODE,I>::pruneNode(NODE* node){
-    
+
     if (!isNodeCollapsible(node))
       return false;
 
@@ -281,7 +281,7 @@ namespace octomap {
 
     return true;
   }
-  
+
   template <class NODE,class I>
   void OcTreeBaseImpl<NODE,I>::allocNodeChildren(NODE* node){
     // TODO NODE*
@@ -290,8 +290,8 @@ namespace octomap {
       node->children[i] = NULL;
     }
   }
-  
-  
+
+
 
   template <class NODE,class I>
   inline key_type OcTreeBaseImpl<NODE,I>::coordToKey(double coordinate, unsigned depth) const{
@@ -540,7 +540,7 @@ namespace octomap {
 
   template <class NODE,class I>
   bool OcTreeBaseImpl<NODE,I>::computeRayKeys(const point3d& origin,
-                                          const point3d& end, 
+                                          const point3d& end,
                                           KeyRay& ray) const {
 
     // see "A Faster Voxel Traversal Algorithm for Ray Tracing" by Amanatides & Woo
@@ -556,7 +556,7 @@ namespace octomap {
       return false;
     }
 
-    
+
     if (key_origin == key_end)
       return true; // same tree cell, we're done.
 
@@ -572,7 +572,7 @@ namespace octomap {
     double tMax[3];
     double tDelta[3];
 
-    OcTreeKey current_key = key_origin; 
+    OcTreeKey current_key = key_origin;
 
     for(unsigned int i=0; i < 3; ++i) {
       // compute step direction
@@ -634,14 +634,14 @@ namespace octomap {
           done = true;
           break;
         }
-        
+
         else {  // continue to add freespace cells
           ray.addKey(current_key);
         }
       }
 
       assert ( ray.size() < ray.sizeMax() - 1);
-      
+
     } // end while
 
     return true;
@@ -657,12 +657,12 @@ namespace octomap {
     }
     return true;
   }
-  
+
   template <class NODE,class I>
   void OcTreeBaseImpl<NODE,I>::deleteNodeRecurs(NODE* node){
     assert(node);
     // TODO: maintain tree size?
-    
+
     if (node->children != NULL) {
       for (unsigned int i=0; i<8; i++) {
         if (node->children[i] != NULL){
@@ -672,10 +672,10 @@ namespace octomap {
       delete[] node->children;
       node->children = NULL;
     } // else: node has no children
-      
+
     delete node;
   }
-  
+
 
   template <class NODE,class I>
   bool OcTreeBaseImpl<NODE,I>::deleteNodeRecurs(NODE* node, unsigned int depth, unsigned int max_depth, const OcTreeKey& key){
@@ -766,11 +766,11 @@ namespace octomap {
 
     return s;
   }
-  
+
   template <class NODE,class I>
   std::ostream& OcTreeBaseImpl<NODE,I>::writeNodesRecurs(const NODE* node, std::ostream &s) const{
     node->writeData(s);
-    
+
     // 1 bit for each children; 0: empty, 1: allocated
     std::bitset<8> children;
     for (unsigned int i=0; i<8; i++) {
@@ -784,7 +784,7 @@ namespace octomap {
     s.write((char*)&children_char, sizeof(char));
 
 //     std::cout << "wrote: " << value << " "
-//               << children.to_string<char,std::char_traits<char>,std::allocator<char> >() 
+//               << children.to_string<char,std::char_traits<char>,std::allocator<char> >()
 //               << std::endl;
 
     // recursively write children
@@ -793,7 +793,7 @@ namespace octomap {
         this->writeNodesRecurs(getNodeChild(node, i), s);
       }
     }
-    
+
     return s;
   }
 
@@ -815,16 +815,16 @@ namespace octomap {
 
     root = new NODE();
     readNodesRecurs(root, s);
-    
+
     tree_size = calcNumNodes();  // compute number of nodes
     return s;
   }
-  
+
   template <class NODE,class I>
   std::istream& OcTreeBaseImpl<NODE,I>::readNodesRecurs(NODE* node, std::istream &s) {
-    
+
     node->readData(s);
-    
+
     char children_char;
     s.read((char*)&children_char, sizeof(char));
     std::bitset<8> children ((unsigned long long) children_char);
@@ -839,7 +839,7 @@ namespace octomap {
         readNodesRecurs(newNode, s);
       }
     }
-    
+
     return s;
   }
 
@@ -853,11 +853,11 @@ namespace octomap {
 
     double size_x, size_y, size_z;
     this->getMetricSize(size_x, size_y,size_z);
-    
+
     // assuming best case (one big array and efficient addressing)
     // we can avoid "ceil" since size already accounts for voxels
-    
-    // Note: this can be larger than the adressable memory 
+
+    // Note: this can be larger than the adressable memory
     //   - size_t may not be enough to hold it!
     return (unsigned long long)((size_x/resolution) * (size_y/resolution) * (size_z/resolution)
         * sizeof(root->getValue()));
@@ -865,7 +865,7 @@ namespace octomap {
   }
 
 
-  // non-const versions, 
+  // non-const versions,
   // change min/max/size_changed members
 
   template <class NODE,class I>
@@ -976,7 +976,7 @@ namespace octomap {
         if (y < my) my = y;
         if (z < mz) mz = z;
       }
-    } // end if size changed 
+    } // end if size changed
     else {
       mx = min_value[0];
       my = min_value[1];
@@ -1004,7 +1004,7 @@ namespace octomap {
         if (y > my) my = y;
         if (z > mz) mz = z;
       }
-    } 
+    }
     else {
       mx = max_value[0];
       my = max_value[1];
@@ -1048,10 +1048,10 @@ namespace octomap {
     assert(depth <= tree_depth);
     if (depth == 0)
       depth = tree_depth;
-    
+
     point3d pmin_clamped = this->keyToCoord(this->coordToKey(pmin, depth), depth);
-    point3d pmax_clamped = this->keyToCoord(this->coordToKey(pmax, depth), depth);    
-    
+    point3d pmax_clamped = this->keyToCoord(this->coordToKey(pmax, depth), depth);
+
     float diff[3];
     unsigned int steps[3];
     float step_size = this->resolution * pow(2, tree_depth-depth);
@@ -1060,7 +1060,7 @@ namespace octomap {
       steps[i] = floor(diff[i] / step_size);
       //      std::cout << "bbx " << i << " size: " << diff[i] << " " << steps[i] << " steps\n";
     }
-    
+
     point3d p = pmin_clamped;
     NODE* res;
     for (unsigned int x=0; x<steps[0]; ++x) {
@@ -1097,7 +1097,7 @@ namespace octomap {
 
     if (!nodeHasChildren(parent)) // this is a leaf -> terminate
       return 1;
-    
+
     size_t sum_leafs_children = 0;
     for (unsigned int i=0; i<8; ++i) {
       if (nodeChildExists(parent, i)) {

--- a/octomap/include/octomap/OcTreeIterator.hxx
+++ b/octomap/include/octomap/OcTreeIterator.hxx
@@ -52,11 +52,11 @@
        * @param tree OcTreeBaseImpl on which the iterator is used on
        * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
        */
-      iterator_base(OcTreeBaseImpl<NodeType,INTERFACE> const* tree, uint8_t depth=0)
-        : tree((tree && tree->root) ? tree : NULL), maxDepth(depth)
+      iterator_base(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, uint8_t depth=0)
+        : tree((ptree && ptree->root) ? ptree : NULL), maxDepth(depth)
       {
-        if (tree && maxDepth == 0)
-          maxDepth = tree->getTreeDepth();
+        if (ptree && maxDepth == 0)
+          maxDepth = ptree->getTreeDepth();
 
         if (tree && tree->root){ // tree is not empty
           StackElement s;
@@ -160,7 +160,7 @@
 
       /// Internal recursion stack. Apparently a stack of vector works fastest here.
       std::stack<StackElement,std::vector<StackElement> > stack;
-      
+
       /// One step of depth-first tree traversal.
       /// How this is used depends on the actual iterator.
       void singleIncrement(){
@@ -213,7 +213,7 @@
        * @param tree OcTreeBaseImpl on which the iterator is used on
        * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
        */
-      tree_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* tree, uint8_t depth=0) : iterator_base(tree, depth) {};
+      tree_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, uint8_t depth=0) : iterator_base(ptree, depth) {};
 
       /// postfix increment operator of iterator (it++)
       tree_iterator operator++(int){
@@ -237,8 +237,8 @@
       }
 
       /// @return whether the current node is a leaf, i.e. has no children or is at max level
-      bool isLeaf() const{ 
-        return (!this->tree->nodeHasChildren(this->stack.top().node) || this->stack.top().depth == this->maxDepth); 
+      bool isLeaf() const{
+        return (!this->tree->nodeHasChildren(this->stack.top().node) || this->stack.top().depth == this->maxDepth);
       }
     };
 
@@ -270,7 +270,7 @@
           * @param tree OcTreeBaseImpl on which the iterator is used on
           * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
           */
-          leaf_iterator(OcTreeBaseImpl<NodeType, INTERFACE> const* tree, uint8_t depth=0) : iterator_base(tree, depth) {
+          leaf_iterator(OcTreeBaseImpl<NodeType, INTERFACE> const* ptree, uint8_t depth=0) : iterator_base(ptree, depth) {
             // tree could be empty (= no stack)
             if (this->stack.size() > 0){
               // skip forward to next valid leaf node:
@@ -298,7 +298,7 @@
               this->stack.pop();
 
               // skip forward to next leaf
-              while(!this->stack.empty()  
+              while(!this->stack.empty()
                   && this->stack.top().depth < this->maxDepth
                   && this->tree->nodeHasChildren(this->stack.top().node))
               {
@@ -350,14 +350,14 @@
       * @param max Maximum point3d of the axis-aligned boundingbox
       * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
       */
-      leaf_bbx_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* tree, const point3d& min, const point3d& max, uint8_t depth=0)
-        : iterator_base(tree, depth)
+      leaf_bbx_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, const point3d& min, const point3d& max, uint8_t depth=0)
+        : iterator_base(ptree, depth)
       {
         if (this->stack.size() > 0){
-          assert(tree);
+          assert(ptree);
           if (!this->tree->coordToKeyChecked(min, minKey) || !this->tree->coordToKeyChecked(max, maxKey)){
             // coordinates invalid, set to end iterator
-            tree = NULL;
+            this->tree = NULL;
             this->maxDepth = 0;
           } else{  // else: keys are generated and stored
 
@@ -378,8 +378,8 @@
       * @param max Maximum OcTreeKey to be included in the axis-aligned boundingbox
       * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
       */
-      leaf_bbx_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* tree, const OcTreeKey& min, const OcTreeKey& max, uint8_t depth=0)
-        : iterator_base(tree, depth), minKey(min), maxKey(max)
+      leaf_bbx_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, const OcTreeKey& min, const OcTreeKey& max, uint8_t depth=0)
+        : iterator_base(ptree, depth), minKey(min), maxKey(max)
       {
         // tree could be empty (= no stack)
         if (this->stack.size() > 0){
@@ -412,7 +412,7 @@
           this->stack.pop();
 
           // skip forward to next leaf
-          while(!this->stack.empty()  
+          while(!this->stack.empty()
               && this->stack.top().depth < this->maxDepth
               && this->tree->nodeHasChildren(this->stack.top().node))
           {

--- a/octomap/include/octomap/OcTreeStamped.h
+++ b/octomap/include/octomap/OcTreeStamped.h
@@ -40,9 +40,9 @@
 #include <ctime>
 
 namespace octomap {
-  
+
   // node definition
-  class OcTreeNodeStamped : public OcTreeNode {    
+  class OcTreeNodeStamped : public OcTreeNode {
 
   public:
     OcTreeNodeStamped() : OcTreeNode(), timestamp(0) {}
@@ -52,19 +52,19 @@ namespace octomap {
     bool operator==(const OcTreeNodeStamped& rhs) const{
       return (rhs.value == value && rhs.timestamp == timestamp);
     }
-    
+
     void copyData(const OcTreeNodeStamped& from){
       OcTreeNode::copyData(from);
       timestamp = from.getTimestamp();
     }
-      
+
     // timestamp
     inline unsigned int getTimestamp() const { return timestamp; }
     inline void updateTimestamp() { timestamp = (unsigned int) time(NULL);}
-    inline void setTimestamp(unsigned int timestamp) {this->timestamp = timestamp; }
+    inline void setTimestamp(unsigned int t) {timestamp = t; }
 
-    // update occupancy and timesteps of inner nodes 
-    inline void updateOccupancyChildren() {      
+    // update occupancy and timesteps of inner nodes
+    inline void updateOccupancyChildren() {
       this->setLogOdds(this->getMaxChildLogOdds());  // conservative
       updateTimestamp();
     }
@@ -75,12 +75,12 @@ namespace octomap {
 
 
   // tree definition
-  class OcTreeStamped : public OccupancyOcTreeBase <OcTreeNodeStamped> {    
+  class OcTreeStamped : public OccupancyOcTreeBase <OcTreeNodeStamped> {
 
   public:
     /// Default constructor, sets resolution of leafs
 	  OcTreeStamped(double resolution);
-      
+
     /// virtual constructor: creates a new object of same type
     /// (Covariant return type requires an up-to-date compiler)
     OcTreeStamped* create() const {return new OcTreeStamped(resolution); }
@@ -91,14 +91,14 @@ namespace octomap {
     unsigned int getLastUpdateTime();
 
     void degradeOutdatedNodes(unsigned int time_thres);
-    
+
     virtual void updateNodeLogOdds(OcTreeNodeStamped* node, const float& update) const;
     void integrateMissNoTime(OcTreeNodeStamped* node) const;
 
   protected:
     /**
      * Static member object which ensures that this OcTree's prototype
-     * ends up in the classIDMapping only once. You need this as a 
+     * ends up in the classIDMapping only once. You need this as a
      * static member in any derived octree class in order to read .ot
      * files through the AbstractOcTree factory. You should also call
      * ensureLinking() once from the constructor.
@@ -120,7 +120,7 @@ namespace octomap {
     };
     /// to ensure static initialization (only once)
     static StaticMemberInitializer ocTreeStampedMemberInit;
-    
+
   };
 
 } // end namespace

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -39,18 +39,18 @@
 namespace octomap {
 
   template <class NODE>
-  OccupancyOcTreeBase<NODE>::OccupancyOcTreeBase(double resolution)
-    : OcTreeBaseImpl<NODE,AbstractOccupancyOcTree>(resolution), use_bbx_limit(false), use_change_detection(false)
+  OccupancyOcTreeBase<NODE>::OccupancyOcTreeBase(double in_resolution)
+    : OcTreeBaseImpl<NODE,AbstractOccupancyOcTree>(in_resolution), use_bbx_limit(false), use_change_detection(false)
   {
 
   }
-  
+
   template <class NODE>
-  OccupancyOcTreeBase<NODE>::OccupancyOcTreeBase(double resolution, unsigned int tree_depth, unsigned int tree_max_val)
-    : OcTreeBaseImpl<NODE,AbstractOccupancyOcTree>(resolution, tree_depth, tree_max_val), use_bbx_limit(false), use_change_detection(false)
+  OccupancyOcTreeBase<NODE>::OccupancyOcTreeBase(double in_resolution, unsigned int in_tree_depth, unsigned int in_tree_max_val)
+    : OcTreeBaseImpl<NODE,AbstractOccupancyOcTree>(in_resolution, in_tree_depth, in_tree_max_val), use_bbx_limit(false), use_change_detection(false)
   {
 
-  }  
+  }
 
   template <class NODE>
   OccupancyOcTreeBase<NODE>::~OccupancyOcTreeBase(){
@@ -376,7 +376,7 @@ namespace octomap {
       if (!this->nodeChildExists(node, pos)) {
         // child does not exist, but maybe it's a pruned node?
         if (!this->nodeHasChildren(node) && !node_just_created ) {
-          // current node does not have children AND it is not a new node 
+          // current node does not have children AND it is not a new node
           // -> expand pruned node
           this->expandNode(node);
         }
@@ -408,7 +408,7 @@ namespace octomap {
     else {
       if (use_change_detection) {
         bool occBefore = this->isNodeOccupied(node);
-        updateNodeLogOdds(node, log_odds_update); 
+        updateNodeLogOdds(node, log_odds_update);
 
         if (node_just_created){  // new node
           changed_keys.insert(std::pair<OcTreeKey,bool>(key, true));
@@ -420,12 +420,12 @@ namespace octomap {
             changed_keys.erase(it);
         }
       } else {
-        updateNodeLogOdds(node, log_odds_update); 
+        updateNodeLogOdds(node, log_odds_update);
       }
       return node;
     }
   }
-  
+
   // TODO: mostly copy of updateNodeRecurs => merge code or general tree modifier / traversal
   template <class NODE>
   NODE* OccupancyOcTreeBase<NODE>::setNodeValueRecurs(NODE* node, bool node_just_created, const OcTreeKey& key,
@@ -546,7 +546,7 @@ namespace octomap {
       nodeToMaxLikelihood(node);
     }
   }
-  
+
   template <class NODE>
   bool OccupancyOcTreeBase<NODE>::getNormals(const point3d& point, std::vector<point3d>& normals,
                                              bool unknownStatus) const {
@@ -574,7 +574,7 @@ namespace octomap {
     // Iterate over the 8 neighboring sets
     for(int m = 0; m < 2; ++m){
       for(int l = 0; l < 4; ++l){
-        
+
         int k = 0;
         // Iterate over the cubes
         for(int j = 0; j < 2; ++j){
@@ -634,9 +634,9 @@ namespace octomap {
 
     return true;
   }
-  
+
   template <class NODE>
-  bool OccupancyOcTreeBase<NODE>::castRay(const point3d& origin, const point3d& directionP, point3d& end, 
+  bool OccupancyOcTreeBase<NODE>::castRay(const point3d& origin, const point3d& directionP, point3d& end,
                                           bool ignoreUnknown, double maxRange) const {
 
     /// ----------  see OcTreeBase::computeRayKeys  -----------
@@ -651,7 +651,7 @@ namespace octomap {
     NODE* startingNode = this->search(current_key);
     if (startingNode){
       if (this->isNodeOccupied(startingNode)){
-        // Occupied node found at origin 
+        // Occupied node found at origin
         // (need to convert from key, since origin does not need to be a voxel center)
         end = this->keyToCoord(current_key);
         return true;
@@ -664,7 +664,7 @@ namespace octomap {
     point3d direction = directionP.normalized();
     bool max_range_set = (maxRange > 0.0);
 
-    int step[3]; 
+    int step[3];
     double tMax[3];
     double tDelta[3];
 
@@ -842,37 +842,37 @@ namespace octomap {
     // Don't start on a bondary.
     if(found)
       intersection = direction * float(outD + delta) + origin;
-    
+
     return found;
   }
 
 
-  template <class NODE> inline bool 
+  template <class NODE> inline bool
   OccupancyOcTreeBase<NODE>::integrateMissOnRay(const point3d& origin, const point3d& end, bool lazy_eval) {
 
     if (!this->computeRayKeys(origin, end, this->keyrays.at(0))) {
       return false;
     }
-    
+
     for(KeyRay::iterator it=this->keyrays[0].begin(); it != this->keyrays[0].end(); it++) {
       updateNode(*it, false, lazy_eval); // insert freespace measurement
     }
-  
+
     return true;
   }
 
-  template <class NODE> bool 
+  template <class NODE> bool
   OccupancyOcTreeBase<NODE>::insertRay(const point3d& origin, const point3d& end, double maxrange, bool lazy_eval)
   {
     // cut ray at maxrange
-    if ((maxrange > 0) && ((end - origin).norm () > maxrange)) 
+    if ((maxrange > 0) && ((end - origin).norm () > maxrange))
       {
         point3d direction = (end - origin).normalized ();
         point3d new_end = origin + direction * (float) maxrange;
         return integrateMissOnRay(origin, new_end,lazy_eval);
       }
     // insert complete ray
-    else 
+    else
       {
         if (!integrateMissOnRay(origin, end,lazy_eval))
           return false;
@@ -880,10 +880,10 @@ namespace octomap {
         return true;
       }
   }
-  
+
   template <class NODE>
-  void OccupancyOcTreeBase<NODE>::setBBXMin (point3d& min) { 
-    bbx_min = min; 
+  void OccupancyOcTreeBase<NODE>::setBBXMin (point3d& min) {
+    bbx_min = min;
     if (!this->coordToKeyChecked(bbx_min, bbx_min_key)) {
       OCTOMAP_ERROR("ERROR while generating bbx min key.\n");
     }
@@ -891,7 +891,7 @@ namespace octomap {
 
   template <class NODE>
   void OccupancyOcTreeBase<NODE>::setBBXMax (point3d& max) {
-    bbx_max = max; 
+    bbx_max = max;
     if (!this->coordToKeyChecked(bbx_max, bbx_max_key)) {
       OCTOMAP_ERROR("ERROR while generating bbx max key.\n");
     }
@@ -938,7 +938,7 @@ namespace octomap {
     this->root = new NODE();
     this->readBinaryNode(s, this->root);
     this->size_changed = true;
-    this->tree_size = OcTreeBaseImpl<NODE,AbstractOccupancyOcTree>::calcNumNodes();  // compute number of nodes    
+    this->tree_size = OcTreeBaseImpl<NODE,AbstractOccupancyOcTree>::calcNumNodes();  // compute number of nodes
     return s;
   }
 
@@ -1108,7 +1108,7 @@ namespace octomap {
   void OccupancyOcTreeBase<NODE>::integrateMiss(NODE* occupancyNode) const {
     updateNodeLogOdds(occupancyNode, this->prob_miss_log);
   }
-  
+
   template <class NODE>
   void OccupancyOcTreeBase<NODE>::nodeToMaxLikelihood(NODE* occupancyNode) const{
     if (this->isNodeOccupied(occupancyNode))

--- a/octomap/src/ColorOcTree.cpp
+++ b/octomap/src/ColorOcTree.cpp
@@ -40,14 +40,14 @@ namespace octomap {
   std::ostream& ColorOcTreeNode::writeData(std::ostream &s) const {
     s.write((const char*) &value, sizeof(value)); // occupancy
     s.write((const char*) &color, sizeof(Color)); // color
-    
+
     return s;
   }
 
-  std::istream& ColorOcTreeNode::readData(std::istream &s) {        
+  std::istream& ColorOcTreeNode::readData(std::istream &s) {
     s.read((char*) &value, sizeof(value)); // occupancy
     s.read((char*) &color, sizeof(Color)); // color
-    
+
     return s;
   }
 
@@ -56,11 +56,11 @@ namespace octomap {
     int mg = 0;
     int mb = 0;
     int c = 0;
-    
+
     if (children != NULL){
       for (int i=0; i<8; i++) {
         ColorOcTreeNode* child = static_cast<ColorOcTreeNode*>(children[i]);
-        
+
         if (child != NULL && child->isColorSet()) {
           mr += child->getColor().r;
           mg += child->getColor().g;
@@ -69,7 +69,7 @@ namespace octomap {
         }
       }
     }
-    
+
     if (c > 0) {
       mr /= c;
       mg /= c;
@@ -82,35 +82,35 @@ namespace octomap {
   }
 
 
-  void ColorOcTreeNode::updateColorChildren() {      
+  void ColorOcTreeNode::updateColorChildren() {
     color = getAverageChildColor();
   }
 
 
   // tree implementation  --------------------------------------
-  ColorOcTree::ColorOcTree(double resolution)
-  : OccupancyOcTreeBase<ColorOcTreeNode>(resolution) {
+  ColorOcTree::ColorOcTree(double in_resolution)
+  : OccupancyOcTreeBase<ColorOcTreeNode>(in_resolution) {
     colorOcTreeMemberInit.ensureLinking();
   };
 
-  ColorOcTreeNode* ColorOcTree::setNodeColor(const OcTreeKey& key, 
-                                             uint8_t r, 
-                                             uint8_t g, 
+  ColorOcTreeNode* ColorOcTree::setNodeColor(const OcTreeKey& key,
+                                             uint8_t r,
+                                             uint8_t g,
                                              uint8_t b) {
     ColorOcTreeNode* n = search (key);
     if (n != 0) {
-      n->setColor(r, g, b); 
+      n->setColor(r, g, b);
     }
     return n;
   }
-  
+
   bool ColorOcTree::pruneNode(ColorOcTreeNode* node) {
-    if (!isNodeCollapsible(node)) 
+    if (!isNodeCollapsible(node))
       return false;
 
     // set value to children's values (all assumed equal)
     node->copyData(*(getNodeChild(node, 0)));
-    
+
     if (node->isColorSet()) // TODO check
       node->setColor(node->getAverageChildColor());
 
@@ -123,13 +123,13 @@ namespace octomap {
 
     return true;
   }
-  
+
   bool ColorOcTree::isNodeCollapsible(const ColorOcTreeNode* node) const{
     // all children must exist, must not have children of
     // their own and have the same occupancy probability
     if (!nodeChildExists(node, 0))
       return false;
-    
+
     const ColorOcTreeNode* firstChild = getNodeChild(node, 0);
     if (nodeHasChildren(firstChild))
       return false;
@@ -139,19 +139,19 @@ namespace octomap {
       if (!nodeChildExists(node, i) || nodeHasChildren(getNodeChild(node, i)) || !(getNodeChild(node, i)->getValue() == firstChild->getValue()))
         return false;
     }
-    
+
     return true;
   }
 
-  ColorOcTreeNode* ColorOcTree::averageNodeColor(const OcTreeKey& key, 
-                                                 uint8_t r, 
-                                                 uint8_t g, 
+  ColorOcTreeNode* ColorOcTree::averageNodeColor(const OcTreeKey& key,
+                                                 uint8_t r,
+                                                 uint8_t g,
                                                  uint8_t b) {
     ColorOcTreeNode* n = search(key);
     if (n != 0) {
       if (n->isColorSet()) {
         ColorOcTreeNode::Color prev_color = n->getColor();
-        n->setColor((prev_color.r + r)/2, (prev_color.g + g)/2, (prev_color.b + b)/2); 
+        n->setColor((prev_color.r + r)/2, (prev_color.g + g)/2, (prev_color.b + b)/2);
       }
       else {
         n->setColor(r, g, b);
@@ -160,22 +160,22 @@ namespace octomap {
     return n;
   }
 
-  ColorOcTreeNode* ColorOcTree::integrateNodeColor(const OcTreeKey& key, 
-                                                   uint8_t r, 
-                                                   uint8_t g, 
+  ColorOcTreeNode* ColorOcTree::integrateNodeColor(const OcTreeKey& key,
+                                                   uint8_t r,
+                                                   uint8_t g,
                                                    uint8_t b) {
     ColorOcTreeNode* n = search (key);
     if (n != 0) {
       if (n->isColorSet()) {
         ColorOcTreeNode::Color prev_color = n->getColor();
         double node_prob = n->getOccupancy();
-        uint8_t new_r = (uint8_t) ((double) prev_color.r * node_prob 
+        uint8_t new_r = (uint8_t) ((double) prev_color.r * node_prob
                                                +  (double) r * (0.99-node_prob));
-        uint8_t new_g = (uint8_t) ((double) prev_color.g * node_prob 
+        uint8_t new_g = (uint8_t) ((double) prev_color.g * node_prob
                                                +  (double) g * (0.99-node_prob));
-        uint8_t new_b = (uint8_t) ((double) prev_color.b * node_prob 
+        uint8_t new_b = (uint8_t) ((double) prev_color.b * node_prob
                                                +  (double) b * (0.99-node_prob));
-        n->setColor(new_r, new_g, new_b); 
+        n->setColor(new_r, new_g, new_b);
       }
       else {
         n->setColor(r, g, b);
@@ -183,8 +183,8 @@ namespace octomap {
     }
     return n;
   }
-  
-  
+
+
   void ColorOcTree::updateInnerOccupancy() {
     this->updateInnerOccupancyRecurs(this->root, 0);
   }
@@ -234,17 +234,17 @@ namespace octomap {
     fprintf(gui, "'-' w l lt 1 lc 2 tit \"\",");
     fprintf(gui, "'-' w l lt 1 lc 3 tit \"\"\n");
 
-    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_r[i]);    
+    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_r[i]);
     fprintf(gui,"0 0\n"); fprintf(gui, "e\n");
-    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_g[i]);    
+    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_g[i]);
     fprintf(gui,"0 0\n"); fprintf(gui, "e\n");
-    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_b[i]);    
+    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_b[i]);
     fprintf(gui,"0 0\n"); fprintf(gui, "e\n");
-    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_r[i]);    
+    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_r[i]);
     fprintf(gui, "e\n");
-    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_g[i]);    
+    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_g[i]);
     fprintf(gui, "e\n");
-    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_b[i]);    
+    for (int i=0; i<256; ++i) fprintf(gui,"%d %d\n", i, histogram_b[i]);
     fprintf(gui, "e\n");
     fflush(gui);
 #endif
@@ -258,4 +258,3 @@ namespace octomap {
   ColorOcTree::StaticMemberInitializer ColorOcTree::colorOcTreeMemberInit;
 
 } // end namespace
-

--- a/octomap/src/CountingOcTree.cpp
+++ b/octomap/src/CountingOcTree.cpp
@@ -49,8 +49,8 @@ namespace octomap {
   }
 
   /// implementation of CountingOcTree  --------------------------------------
-  CountingOcTree::CountingOcTree(double resolution)
-   : OcTreeBase<CountingOcTreeNode>(resolution) {
+  CountingOcTree::CountingOcTree(double in_resolution)
+   : OcTreeBase<CountingOcTreeNode>(in_resolution) {
       countingOcTreeMemberInit.ensureLinking();
    }
 

--- a/octomap/src/OcTree.cpp
+++ b/octomap/src/OcTree.cpp
@@ -36,8 +36,8 @@
 
 namespace octomap {
 
-	OcTree::OcTree(double resolution) 
-		: OccupancyOcTreeBase<OcTreeNode>(resolution) {
+	OcTree::OcTree(double in_resolution)
+		: OccupancyOcTreeBase<OcTreeNode>(in_resolution) {
 		ocTreeMemberInit.ensureLinking();
 	};
 
@@ -48,7 +48,7 @@ namespace octomap {
 
   OcTree::StaticMemberInitializer OcTree::ocTreeMemberInit;
 
-  
+
 
 
 } // namespace

--- a/octomap/src/OcTreeStamped.cpp
+++ b/octomap/src/OcTreeStamped.cpp
@@ -35,28 +35,28 @@
 
 namespace octomap {
 
-  OcTreeStamped::OcTreeStamped(double resolution)
-   : OccupancyOcTreeBase<OcTreeNodeStamped>(resolution) {
+  OcTreeStamped::OcTreeStamped(double in_resolution)
+   : OccupancyOcTreeBase<OcTreeNodeStamped>(in_resolution) {
     ocTreeStampedMemberInit.ensureLinking();
   }
 
   unsigned int OcTreeStamped::getLastUpdateTime() {
-    // this value is updated whenever inner nodes are 
+    // this value is updated whenever inner nodes are
     // updated using updateOccupancyChildren()
     return root->getTimestamp();
   }
 
   void OcTreeStamped::degradeOutdatedNodes(unsigned int time_thres) {
-    unsigned int query_time = (unsigned int) time(NULL); 
+    unsigned int query_time = (unsigned int) time(NULL);
 
-    for(leaf_iterator it = this->begin_leafs(), end=this->end_leafs(); 
+    for(leaf_iterator it = this->begin_leafs(), end=this->end_leafs();
         it!= end; ++it) {
-      if ( this->isNodeOccupied(*it) 
+      if ( this->isNodeOccupied(*it)
            && ((query_time - it->getTimestamp()) > time_thres) ) {
         integrateMissNoTime(&*it);
       }
     }
-  }  
+  }
 
   void OcTreeStamped::updateNodeLogOdds(OcTreeNodeStamped* node, const float& update) const {
     OccupancyOcTreeBase<OcTreeNodeStamped>::updateNodeLogOdds(node, update);
@@ -70,4 +70,3 @@ namespace octomap {
   OcTreeStamped::StaticMemberInitializer OcTreeStamped::ocTreeStampedMemberInit;
 
 } // end namespace
-

--- a/octomap/src/binvox2bt.cpp
+++ b/octomap/src/binvox2bt.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
     int size;                  // number of grid cells (height * width * depth)
     float tx, ty, tz;          // Translation
     float scale;               // Scaling factor
-    bool mark_free = false;    // Mark free cells (false = cells remain "unknown")    
+    bool mark_free = false;    // Mark free cells (false = cells remain "unknown")
     bool rotate = false;       // Fix orientation of webots-exported files
     bool show_help = false;
     string output_filename;
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
           )
                show_help = true;
     }
-    
+
     if(show_help) {
         cout << "Usage: "<<argv[0]<<" [OPTIONS] <binvox filenames>" << endl;
         cout << "\tOPTIONS:" << endl;
@@ -101,9 +101,9 @@ int main(int argc, char **argv)
         cout << "All options apply to the subsequent input files.\n\n";
         exit(0);
     }
-    
+
     for(int i = 1; i < argc; i++) {
-        // Parse command line arguments    
+        // Parse command line arguments
         if(strcmp(argv[i], "--mark-free") == 0) {
             mark_free = true;
             continue;
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
         }else if(strcmp(argv[i], "--rotate") == 0) {
           rotate = true;
           continue;
-        } else if(strcmp(argv[i], "-o") == 0 && i < argc - 1) {            
+        } else if(strcmp(argv[i], "-o") == 0 && i < argc - 1) {
             i++;
             output_filename = argv[i];
 
@@ -150,13 +150,13 @@ int main(int argc, char **argv)
 
 
         // Open input file
-        ifstream *input = new ifstream(argv[i], ios::in | ios::binary);    
+        ifstream *input = new ifstream(argv[i], ios::in | ios::binary);
         if(!input->good()) {
             cerr << "Error: Could not open input file " << argv[i] << "!" << endl;
             exit(1);
         } else {
             cout << "Reading binvox file " << argv[i] << "." << endl;
-            if(output_filename.empty()) { 
+            if(output_filename.empty()) {
                 output_filename = string(argv[i]).append(".bt");
             }
         }
@@ -222,10 +222,10 @@ int main(int argc, char **argv)
         	std::cout << "Offset on final map: "<< offset << std::endl;
 
         }
-                
+
         cout << "Read data: ";
         cout.flush();
-            
+
         // read voxel data
         byte value;
         byte count;
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
         int end_index = 0;
         unsigned nr_voxels = 0;
         unsigned nr_voxels_out = 0;
-        
+
         input->unsetf(ios::skipws);    // need to read every byte now (!)
         *input >> value;    // read the linefeed char
 
@@ -243,19 +243,19 @@ int main(int argc, char **argv)
             if (input->good()) {
                 end_index = index + count;
                 if (end_index > size) return 0;
-                for(int i=index; i < end_index; i++) {
+                for(int j=index; j < end_index; j++) {
                     // Output progress dots
-                    if(i % (size / 20) == 0) {
-                        cout << ".";            
+                    if(j % (size / 20) == 0) {
+                        cout << ".";
                         cout.flush();
                     }
-                    // voxel index --> voxel coordinates 
-                    int y = i % width;
-                    int z = (i / width) % height;
-                    int x = i / (width * height);
-                    
+                    // voxel index --> voxel coordinates
+                    int y = j % width;
+                    int z = (j / width) % height;
+                    int x = j / (width * height);
+
                     // voxel coordinates --> world coordinates
-                    point3d endpoint((float) ((double) x*res + tx + 0.000001), 
+                    point3d endpoint((float) ((double) x*res + tx + 0.000001),
                                      (float) ((double) y*res + ty + 0.000001),
                                      (float) ((double) z*res + tz + 0.000001));
 
@@ -264,7 +264,7 @@ int main(int argc, char **argv)
                     }
                     if (applyOffset)
                     	endpoint += offset;
-                    
+
                     if (!applyBBX  || (endpoint(0) <= maxX && endpoint(0) >= minX
                                    && endpoint(1) <= maxY && endpoint(1) >= minY
                                    && endpoint(2) <= maxZ && endpoint(2) >= minZ)){
@@ -277,32 +277,32 @@ int main(int argc, char **argv)
                       nr_voxels_out ++;
                     }
                 }
-                
+
                 if (value) nr_voxels += count;
                 index = end_index;
             }    // if file still ok
-            
+
         }    // while
-        
+
         cout << endl << endl;
 
         input->close();
         cout << "    read " << nr_voxels << " voxels, skipped "<<nr_voxels_out << " (out of bounding box)\n\n";
     }
-    
+
     // prune octree
     cout << "Pruning octree" << endl << endl;
     tree->updateInnerOccupancy();
     tree->prune();
- 
-    // write octree to file  
+
+    // write octree to file
     if(output_filename.empty()) {
         cerr << "Error: No input files found." << endl << endl;
         exit(1);
     }
 
     cout << "Writing octree to " << output_filename << endl << endl;
-   
+
     tree->writeBinary(output_filename.c_str());
 
     cout << "done" << endl << endl;

--- a/octovis/src/OcTreeDrawer.cpp
+++ b/octovis/src/OcTreeDrawer.cpp
@@ -62,8 +62,8 @@ namespace octomap {
 
   void OcTreeDrawer::draw() const {
     static int gl_list_index = -1;
-    if(m_alternativeDrawing && gl_list_index < 0){ 
-      gl_list_index = glGenLists(1); 
+    if(m_alternativeDrawing && gl_list_index < 0){
+      gl_list_index = glGenLists(1);
       m_update = true;
     }
     if(!m_alternativeDrawing && gl_list_index != -1){//Free video card memory
@@ -72,10 +72,10 @@ namespace octomap {
       gl_list_index = -1;
     }
     if(m_update || !m_alternativeDrawing)
-    { 
-      if(m_alternativeDrawing) { 
+    {
+      if(m_alternativeDrawing) {
         std::cout << "Preparing batch rendering, please wait ...\n";
-        glNewList(gl_list_index, GL_COMPILE_AND_EXECUTE); 
+        glNewList(gl_list_index, GL_COMPILE_AND_EXECUTE);
       }
 
       // push current status
@@ -87,7 +87,7 @@ namespace octomap {
       // apply relative transform
       const octomath::Quaternion& q = relative_transform.rot();
       glTranslatef(relative_transform.x(), relative_transform.y(), relative_transform.z());
-      
+
       // convert quaternion to angle/axis notation
       float scale = sqrt(q.x() * q.x() + q.y() * q.y() + q.z() * q.z());
       if (scale) {
@@ -117,8 +117,8 @@ namespace octomap {
 
       // reset previous status
       glPopMatrix();
-      if(m_alternativeDrawing) { 
-        glEndList(); 
+      if(m_alternativeDrawing) {
+        glEndList();
         std::cout << "Finished preparation of batch rendering.\n";
       }
       m_update = false;
@@ -127,7 +127,7 @@ namespace octomap {
     {
       glCallList(gl_list_index);
     }
-    
+
   }
 
   void OcTreeDrawer::setAlphaOccupied(double alpha){
@@ -136,17 +136,17 @@ namespace octomap {
   }
 
 
-  void OcTreeDrawer::setOcTree(const AbstractOcTree& tree, const pose6d& origin, int map_id_) {
-      
-    const OcTree& octree = (const OcTree&) tree;
+  void OcTreeDrawer::setOcTree(const AbstractOcTree& in_tree, const pose6d& in_origin, int map_id_) {
+
+    const OcTree& octree = (const OcTree&) in_tree;
     this->map_id = map_id_;
 
     // save origin used during cube generation
-    this->initial_origin = octomap::pose6d(octomap::point3d(0,0,0), origin.rot());
+    this->initial_origin = octomap::pose6d(octomap::point3d(0,0,0), in_origin.rot());
 
     // origin is in global coords
-    this->origin = origin;
-    
+    this->origin = in_origin;
+
     // maximum size to prevent crashes on large maps: (should be checked in a better way than a constant)
     bool showAll = (octree.size() < 5 * 1e6);
     bool uses_origin = ( (origin.rot().x() != 0.) && (origin.rot().y() != 0.)
@@ -158,7 +158,7 @@ namespace octomap {
     unsigned int cnt_occupied(0), cnt_occupied_thres(0), cnt_free(0), cnt_free_thres(0);
     for(OcTree::tree_iterator it = octree.begin_tree(this->m_max_tree_depth),
             end=octree.end_tree(); it!= end; ++it) {
-      if (it.isLeaf()) { 
+      if (it.isLeaf()) {
         if (octree.isNodeOccupied(*it)){ // occupied voxels
           if (octree.isNodeAtThreshold(*it)) ++cnt_occupied_thres;
           else                               ++cnt_occupied;
@@ -167,8 +167,8 @@ namespace octomap {
           if (octree.isNodeAtThreshold(*it)) ++cnt_free_thres;
           else                               ++cnt_free;
         }
-      }        
-    }    
+      }
+    }
     // setup GL arrays for cube quads and cube colors
     initGLArrays(cnt_occupied      , m_occupiedSize     , &m_occupiedArray     , &m_occupiedColorArray);
     initGLArrays(cnt_occupied_thres, m_occupiedThresSize, &m_occupiedThresArray, &m_occupiedThresColorArray);
@@ -190,16 +190,16 @@ namespace octomap {
     unsigned int color_idx_occupied(0), color_idx_occupied_thres(0);
 
     m_grid_voxels.clear();
-    OcTreeVolume voxel; // current voxel, possibly transformed 
+    OcTreeVolume voxel; // current voxel, possibly transformed
     for(OcTree::tree_iterator it = octree.begin_tree(this->m_max_tree_depth),
             end=octree.end_tree(); it!= end; ++it) {
 
       if (it.isLeaf()) { // voxels for leaf nodes
-        if (uses_origin) 
+        if (uses_origin)
           voxel = OcTreeVolume(origin.rot().rotate(it.getCoordinate()), it.getSize());
-        else 
+        else
           voxel = OcTreeVolume(it.getCoordinate(), it.getSize());
-        
+
         if (octree.isNodeOccupied(*it)){ // occupied voxels
           if (octree.isNodeAtThreshold(*it)) {
             idx_occupied_thres = generateCube(voxel, cube_template, idx_occupied_thres, &m_occupiedThresArray);
@@ -219,7 +219,7 @@ namespace octomap {
           }
         }
       }
-      
+
       else { // inner node voxels (for grid structure only)
         if (showAll) {
           if (uses_origin)
@@ -228,7 +228,7 @@ namespace octomap {
             voxel = OcTreeVolume(it.getCoordinate(), it.getSize());
           m_grid_voxels.push_back(voxel);
         }
-      }      
+      }
     } // end for all voxels
 
     m_octree_grid_vis_initialized = false;
@@ -308,7 +308,7 @@ namespace octomap {
     // epsilon to be substracted from cube size so that neighboring planes don't overlap
     // seems to introduce strange artifacts nevertheless...
     double eps = 1e-5;
-    
+
     octomath::Vector3 p;
 
     double half_cube_size = GLfloat(v.second /2.0 -eps);
@@ -333,19 +333,19 @@ namespace octomap {
     (*glArray)[2][i+2] = p.z();
 
     p = v.first + cube_template[3] * half_cube_size;
-    (*glArray)[3][i]   = p.x(); 
-    (*glArray)[3][i+1] = p.y(); 
-    (*glArray)[3][i+2] = p.z(); 
+    (*glArray)[3][i]   = p.x();
+    (*glArray)[3][i+1] = p.y();
+    (*glArray)[3][i+2] = p.z();
 
     p = v.first + cube_template[4] * half_cube_size;
-    (*glArray)[4][i]   = p.x(); 
-    (*glArray)[4][i+1] = p.y(); 
-    (*glArray)[4][i+2] = p.z(); 
+    (*glArray)[4][i]   = p.x();
+    (*glArray)[4][i+1] = p.y();
+    (*glArray)[4][i+2] = p.z();
 
     p = v.first + cube_template[5] * half_cube_size;
-    (*glArray)[5][i]   = p.x(); 
-    (*glArray)[5][i+1] = p.y(); 
-    (*glArray)[5][i+2] = p.z(); 
+    (*glArray)[5][i]   = p.x();
+    (*glArray)[5][i+1] = p.y();
+    (*glArray)[5][i+2] = p.z();
     i+= 3;  //-------------------
 
     p = v.first + cube_template[6] * half_cube_size;
@@ -440,7 +440,7 @@ namespace octomap {
     (*glArray)[5][i+1] = p.y();
     (*glArray)[5][i+2] = p.z();
     i += 3;  //-------------------
-    
+
     return i; // updated array idx
   }
 
@@ -461,7 +461,7 @@ namespace octomap {
       // set Alpha value:
       (*glColorArray)[colorIdx + 3] = m_alphaOccupied;
       colorIdx += 4;
-    }  
+    }
     return colorIdx;
   }
 
@@ -481,7 +481,7 @@ namespace octomap {
       (*glColorArray)[colorIdx + 2] = (double) b/255.;
       (*glColorArray)[colorIdx + 3] = (double) a/255.;
       colorIdx += 4;
-    }  
+    }
     return colorIdx;
   }
 
@@ -515,13 +515,13 @@ namespace octomap {
     std::vector<octomath::Vector3> cube_template;
     initCubeTemplate(origin, cube_template);
 
-    for (std::list<octomap::OcTreeVolume>::const_iterator it=voxels.begin(); 
+    for (std::list<octomap::OcTreeVolume>::const_iterator it=voxels.begin();
          it != voxels.end(); it++) {
       i = generateCube(*it, cube_template, i, glArray);
     }
 
     if (glColorArray != NULL) {
-      for (std::list<octomap::OcTreeVolume>::const_iterator it=voxels.begin(); 
+      for (std::list<octomap::OcTreeVolume>::const_iterator it=voxels.begin();
            it != voxels.end(); it++) {
         colorIdx = setCubeColorHeightmap(*it, colorIdx, glColorArray);
       }
@@ -687,7 +687,7 @@ namespace octomap {
       }
       drawCubes(m_occupiedThresArray, m_occupiedThresSize, m_occupiedThresColorArray);
     }
-    else {      
+    else {
       // colors for printout mode:
       if (m_colorMode == CM_PRINTOUT) {
         if (!m_drawFree) { // gray on white background
@@ -695,7 +695,7 @@ namespace octomap {
         }
         else {
           glColor3f(0.1f, 0.1f, 0.1f);
-        }  
+        }
       }
 
       // draw binary occupied cells
@@ -858,7 +858,7 @@ namespace octomap {
 
 
   void OcTreeDrawer::setOrigin(octomap::pose6d t){
-    origin = t;  
+    origin = t;
     std::cout << "OcTreeDrawer: setting new global origin: " << t << std::endl;
 
     octomap::pose6d relative_transform = origin * initial_origin.inv();
@@ -874,7 +874,7 @@ namespace octomap {
 
     glPushMatrix();
 
-    float length = 0.15f; 
+    float length = 0.15f;
 
     GLboolean lighting, colorMaterial;
     glGetBooleanv(GL_LIGHTING, &lighting);
@@ -883,8 +883,8 @@ namespace octomap {
     glDisable(GL_COLOR_MATERIAL);
 
     double angle= 2 * acos(initial_origin.rot().u());
-    double scale = sqrt (initial_origin.rot().x()*initial_origin.rot().x() 
-                         + initial_origin.rot().y()*initial_origin.rot().y() 
+    double scale = sqrt (initial_origin.rot().x()*initial_origin.rot().x()
+                         + initial_origin.rot().y()*initial_origin.rot().y()
                          + initial_origin.rot().z()*initial_origin.rot().z());
     double ax= initial_origin.rot().x() / scale;
     double ay= initial_origin.rot().y() / scale;
@@ -922,5 +922,3 @@ namespace octomap {
   }
 
 } // namespace
-
-

--- a/octovis/src/extern/QGLViewer/quaternion.h
+++ b/octovis/src/extern/QGLViewer/quaternion.h
@@ -6,10 +6,10 @@
 
  http://www.libqglviewer.com - contact@libqglviewer.com
 
- This file may be used under the terms of the GNU General Public License 
+ This file may be used under the terms of the GNU General Public License
  versions 2.0 or 3.0 as published by the Free Software Foundation and
  appearing in the LICENSE file included in the packaging of this file.
- In addition, as a special exception, Gilles Debunne gives you certain 
+ In addition, as a special exception, Gilles Debunne gives you certain
  additional rights, described in the file GPL_EXCEPTION in this package.
 
  libQGLViewer uses dual licensing. Commercial/proprietary software must
@@ -175,18 +175,18 @@ public:
 
 		\note For efficiency reasons, the resulting Quaternion is not normalized.
 		You may normalize() it after each application in case of numerical drift. */
-	Quaternion& operator*=(const Quaternion &q)
+	Quaternion& operator*=(const Quaternion &quat)
 	{
-		*this = (*this)*q;
+		*this = (*this)*quat;
 		return *this;
 	}
 
 	/*! Returns the image of \p v by the rotation \p q.
 
 		Same as q.rotate(v). See rotate() and inverseRotate(). */
-	friend Vec operator*(const Quaternion& q, const Vec& v)
+	friend Vec operator*(const Quaternion& quat, const Vec& v)
 	{
-		return q.rotate(v);
+		return quat.rotate(v);
 	}
 
 	Vec rotate(const Vec& v) const;


### PR DESCRIPTION
That's it... tested with gcc 7.2, this patch avoids tons of warnings related to shadowed local variables and members.

All tests pass.

PS: Yes, `-Wshadow` may be quite a pedantic flag, but I think shadowing is a think to avoid ;-) At the very least, the ambiguity can be confusing to a reader.