### PR TITLE
Add missing typename keyword

### DIFF
--- a/octomap/include/octomap/OcTreeBaseImpl.hxx
+++ b/octomap/include/octomap/OcTreeBaseImpl.hxx
@@ -129,10 +129,10 @@ namespace octomap {
     }
 
     // traverse all nodes, check if structure the same
-    OcTreeBaseImpl<NODE,I>::tree_iterator it = this->begin_tree();
-    OcTreeBaseImpl<NODE,I>::tree_iterator end = this->end_tree();
-    OcTreeBaseImpl<NODE,I>::tree_iterator other_it = other.begin_tree();
-    OcTreeBaseImpl<NODE,I>::tree_iterator other_end = other.end_tree();
+    typename OcTreeBaseImpl<NODE,I>::tree_iterator it = this->begin_tree();
+    typename OcTreeBaseImpl<NODE,I>::tree_iterator end = this->end_tree();
+    typename OcTreeBaseImpl<NODE,I>::tree_iterator other_it = other.begin_tree();
+    typename OcTreeBaseImpl<NODE,I>::tree_iterator other_end = other.end_tree();
 
     for (; it != end; ++it, ++other_it){
       if (other_it == other_end)


### PR DESCRIPTION
This PR adds `typename` keyword to dependent type names. [Here](https://stackoverflow.com/a/613132/3122234) is a reference for why `typename` keyword is necessary. This patch is to fix the [build failures on Windows](https://ci.appveyor.com/project/jslee02/dart/build/5522/job/8r6c3sfjb05u5t22#L1454).

Caveat: I haven't built Octomap on Windows with this patch because I don't have a Windows machine currently so there could be other issues.