### PR TITLE
c++: fix issue with byte typedef when compiling using C++17

### DIFF
--- a/octomap/src/binvox2bt.cpp
+++ b/octomap/src/binvox2bt.cpp
@@ -56,7 +56,9 @@
 using namespace std;
 using namespace octomap;
 
-typedef unsigned char byte;
+#if __cplusplus < 201500L
+ typedef unsigned char byte;
+#endif
 
 int main(int argc, char **argv)
 {

--- a/octomap/src/edit_octree.cpp
+++ b/octomap/src/edit_octree.cpp
@@ -41,7 +41,9 @@
 using namespace std;
 using namespace octomap;
 
-typedef unsigned char byte;
+#if __cplusplus < 201500L
+  typedef unsigned char byte;
+#endif
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
byte is defined in <cstddef> since C++17