### PR TITLE
Removed problematic INSTALL_NAME_DIR

### DIFF
--- a/octomap/src/math/CMakeLists.txt
+++ b/octomap/src/math/CMakeLists.txt
@@ -10,9 +10,7 @@ ADD_LIBRARY( octomath SHARED ${octomath_SRCS})
 SET_TARGET_PROPERTIES( octomath PROPERTIES
   VERSION ${OCTOMAP_VERSION}
   SOVERSION ${OCTOMAP_SOVERSION}
-  INSTALL_NAME_DIR ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}   # this seems to be necessary for MacOS X
 )
-# INSTALL_NAME_DIR seems to be necessary for MacOS X
 
 ADD_LIBRARY( octomath-static STATIC ${octomath_SRCS})
 SET_TARGET_PROPERTIES(octomath-static PROPERTIES OUTPUT_NAME "octomath")


### PR DESCRIPTION
The `INSTALL_NAME_DIR` interfered with CMake's install process. With it in place, linkage looked like this:

```
$ otool -L /usr/local/lib/liboctomap.1.9.0.dylib 
/usr/local/lib/liboctomap.1.9.0.dylib:
	@rpath/liboctomap.1.9.dylib (compatibility version 1.9.0, current version 1.9.0)
	/Users/bo/Downloads/octomap-1.9.0/octomap/lib/liboctomath.1.9.dylib (compatibility version 1.9.0, current version 1.9.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```

This clearly doesn't look right - it has references the build directory rather than the install directory.

Upon removing `INSTALL_NAME_DIR`, we get the much better looking:

```
$ otool -L /usr/local/lib/liboctomap.1.9.0.dylib 
/usr/local/lib/liboctomap.1.9.0.dylib:
	@rpath/liboctomap.1.9.dylib (compatibility version 1.9.0, current version 1.9.0)
	@rpath/liboctomath.1.9.dylib (compatibility version 1.9.0, current version 1.9.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```

For the avoidance of doubt, here's what `@rpath` is:

```
$ otool -l /usr/local/lib/liboctomap.1.9.0.dylib
[-snip-]
Load command 15
          cmd LC_RPATH
      cmdsize 72
         path /usr/local/lib (offset 12)
```

I do note the comment saying that `INSTALL_NAME_DIR` "seems to be necessary". Looking back, I couldn't find a precise reason why but it was added 8 years ago. CMake at that point had very poor install support on macOS - it didn't even know what an `@rpath` was. Now it has very good support and you rarely need to worry about it.