### PR TITLE
Update package.xml to remove catkin dependency

### DIFF
--- a/dynamicEDT3D/package.xml
+++ b/dynamicEDT3D/package.xml
@@ -1,25 +1,20 @@
-<package>
+<package format="2">
   <name>dynamic_edt_3d</name>
   <version>1.9.0</version>
   <description> The dynamicEDT3D library implements an inrementally updatable Euclidean distance transform (EDT) in 3D. It comes with a wrapper to use the OctoMap 3D representation and hooks into the change detection of the OctoMap library to propagate changes to the EDT.</description>
 
   <author email="sprunkc@informatik.uni-freiburg.de">Christoph Sprunk</author>
   <maintainer email="sprunkc@informatik.uni-freiburg.de">Christoph Sprunk</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
 
   <url type="website">http://octomap.github.io</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
 
-  <build_depend>octomap</build_depend>
-
-  <run_depend>octomap</run_depend>  
-  <run_depend>catkin</run_depend>
-
+  <depend>octomap</depend>
   <buildtool_depend>cmake</buildtool_depend>
 
-  
   <export>
     <build_type>cmake</build_type>
   </export>
-  
 </package>

--- a/octomap/package.xml
+++ b/octomap/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>octomap</name>
   <version>1.9.0</version>
   <description>The OctoMap library implements a 3D occupancy grid mapping approach, providing data structures and mapping algorithms in C++. The map implementation is based on an octree. See
@@ -7,16 +7,15 @@
   <author email="wurm@informatik.uni-freiburg.de">Kai M. Wurm</author>
   <author email="armin@hornung.io">Armin Hornung</author>
   <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
 
   <url type="website">http://octomap.github.io</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
-  
-  <run_depend>catkin</run_depend>
+
   <buildtool_depend>cmake</buildtool_depend>
-  
+
   <export>
     <build_type>cmake</build_type>
   </export>
-  
 </package>

--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>octovis</name>
   <version>1.9.0</version>
   <description>octovis is visualization tool for the OctoMap library based on Qt and libQGLViewer. See
@@ -7,27 +7,21 @@
   <author email="wurm@informatik.uni-freiburg.de">Kai M. Wurm</author>
   <author email="armin@hornung.io">Armin Hornung</author>
   <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>GPLv2</license>
 
   <url type="website">http://octomap.github.io</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
-  
 
-  <run_depend>catkin</run_depend>
   <buildtool_depend>cmake</buildtool_depend>
   
   <export>
     <build_type>cmake</build_type>
   </export>
       
-  <build_depend>octomap</build_depend>
-  <build_depend>libqglviewer-qt4-dev</build_depend>
-  <build_depend>libqt4-dev</build_depend>
-  <build_depend>libqt4-opengl-dev</build_depend>
- 
-  <run_depend>octomap</run_depend>
-  <run_depend>libqglviewer-qt4</run_depend>
-  <run_depend>libqtgui4</run_depend>
-  <run_depend>libqt4-opengl</run_depend>
-  
+  <depend>octomap</depend>
+  <depend>libqglviewer-qt4</depend>
+  <depend>libqt4-dev</depend>
+  <depend>libqt4-opengl-dev</depend>
+  <depend>libqtgui4</depend>
 </package>


### PR DESCRIPTION
- We don't need to specify a catkin dependency (and it fails to resolve on ROS2). 
- Required for #237 
- I plan to make a 1.9.1 release using these changes and the 16 commits between 1.9.0 and the current devel