### PR TITLE
Fix warnings: friend operators not declared within the same namespace

### DIFF
--- a/octovis/src/extern/QGLViewer/VRender/NVector3.h
+++ b/octovis/src/extern/QGLViewer/VRender/NVector3.h
@@ -115,6 +115,9 @@ namespace vrender
 
   }; // interface of NVector3
 
+  double operator*(const NVector3 &u,const Vector3  &v);
+  double operator*(const Vector3  &u,const NVector3 &v);
+
 }
 
 #endif // _NVECTOR3_H

--- a/octovis/src/extern/QGLViewer/VRender/Primitive.h
+++ b/octovis/src/extern/QGLViewer/VRender/Primitive.h
@@ -66,6 +66,8 @@ namespace vrender
 	class Feedback3DColor ;
 	class Primitive ;
 
+	std::ostream& operator<<(std::ostream&,const Feedback3DColor&);
+
 #define EPS_SMOOTH_LINE_FACTOR 0.06  /* Lower for better smooth lines. */
 
 	//  A Feedback3DColor is a structure containing informations about a vertex projected into

--- a/octovis/src/extern/QGLViewer/VRender/Vector2.h
+++ b/octovis/src/extern/QGLViewer/VRender/Vector2.h
@@ -176,6 +176,8 @@ namespace vrender
 			double _xyz[2];  //!< The 3 vector components
 
 	}; // interface of Vector2
+
+	Vector2 operator- (const Vector2&);	
 }
 
 #endif // _VECTOR2_H

--- a/octovis/src/extern/QGLViewer/VRender/Vector3.h
+++ b/octovis/src/extern/QGLViewer/VRender/Vector3.h
@@ -191,5 +191,8 @@ namespace vrender
 			double _xyz[3];  //!< The 3 vector components
 
 	}; // interface of Vector3
+
+	Vector3 operator* (double,const Vector3&);
+	std::ostream& operator<< (std::ostream&,const Vector3&);
 }
 #endif // _VECTOR3_H


### PR DESCRIPTION
This PR intends to fix the warnings shown up in the MoveIt 2 [CI result](https://travis-ci.org/ros-planning/moveit2/jobs/612461783#L657).

Those warning messages are:
```cpp
VRender/Primitive.cpp:165:15: warning: ‘std::ostream& vrender::operator<<(std::ostream&, const vrender::Feedback3DColor&)’ has not been declared within vrender
 std::ostream& vrender::operator<<(std::ostream& o,const Feedback3DColor& f)
               ^~~~~~~
In file included from VRender/Primitive.cpp:47:0:
VRender/Primitive.h:105:24: note: only here as a friend
   friend std::ostream& operator<<(std::ostream&,const Feedback3DColor&) ;
                        ^~~~~~~~
VRender/Vector2.cpp:94:9: warning: ‘vrender::Vector2 vrender::operator-(const vrender::Vector2&)’ has not been declared within vrender
 Vector2 vrender::operator- (const Vector2& u)
         ^~~~~~~
In file included from VRender/Vector2.cpp:45:0:
VRender/Vector2.h:117:19: note: only here as a friend
    friend Vector2 operator- (const Vector2&);
                   ^~~~~~~~
VRender/Vector3.cpp:125:9: warning: ‘vrender::Vector3 vrender::operator*(double, const vrender::Vector3&)’ has not been declared within vrender
 Vector3 vrender::operator* (double r,const Vector3& u)
         ^~~~~~~
In file included from VRender/Vector3.cpp:46:0:
VRender/Vector3.h:158:19: note: only here as a friend
    friend Vector3 operator* (double,const Vector3&);
                   ^~~~~~~~
VRender/Vector3.cpp:155:15: warning: ‘std::ostream& vrender::operator<<(std::ostream&, const vrender::Vector3&)’ has not been declared within vrender
 std::ostream& vrender::operator<< (std::ostream& out,const Vector3& u)
               ^~~~~~~
In file included from VRender/Vector3.cpp:46:0:
VRender/Vector3.h:171:25: note: only here as a friend
    friend std::ostream& operator<< (std::ostream&,const Vector3&);
                         ^~~~~~~~
VRender/NVector3.cpp:85:8: warning: ‘double vrender::operator*(const vrender::NVector3&, const vrender::Vector3&)’ has not been declared within vrender
 double vrender::operator*(const NVector3 &u,const Vector3  &v)
        ^~~~~~~
In file included from VRender/NVector3.cpp:45:0:
VRender/NVector3.h:89:19: note: only here as a friend
     friend double operator*(const NVector3 &u,const Vector3  &v);
                   ^~~~~~~~
VRender/NVector3.cpp:90:8: warning: ‘double vrender::operator*(const vrender::Vector3&, const vrender::NVector3&)’ has not been declared within vrender
 double vrender::operator*(const Vector3  &u,const NVector3 &v)
        ^~~~~~~
In file included from VRender/NVector3.cpp:45:0:
VRender/NVector3.h:90:19: note: only here as a friend
     friend double operator*(const Vector3  &u,const NVector3 &v);
                   ^~~~~~~~
```