### PR TITLE
fix unused-parameter warning

### DIFF
--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -113,7 +113,7 @@ namespace octomap {
 
 
   template <class NODE>
-  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double maxrange, bool lazy_eval) {
+  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double /* maxrange */, bool lazy_eval) {
     if (pc.size() < 1)
       return;
 


### PR DESCRIPTION
`OccupancyOcTreeBase<NODE>::insertPointCloudRays` has an unused parameter!
To silence compiler warnings `-Wunused-parameter`, I commented the parameter name.