### PR TITLE
Fix ROS Melodic/Dashing buildfarm failures

### DIFF
--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -19,9 +19,13 @@
     <build_type>cmake</build_type>
   </export>
       
-  <depend>octomap</depend>
-  <depend>libqglviewer-qt4</depend>
-  <depend>libqt4-dev</depend>
-  <depend>libqt4-opengl-dev</depend>
-  <depend>libqtgui4</depend>
+  <build_depend>octomap</build_depend>
+  <build_depend>libqglviewer-qt4-dev</build_depend>
+  <build_depend>libqt4-dev</build_depend>
+  <build_depend>libqt4-opengl-dev</build_depend>
+
+  <exec_depend>octomap</exec_depend>
+  <exec_depend>libqglviewer-qt4</exec_depend>
+  <exec_depend>libqtgui4</exec_depend>
+  <exec_depend>libqt4-opengl</exec_depend>
 </package>


### PR DESCRIPTION
octovis is currently failing on the ROS Melodic and Dashing buildfarms because my previous PR accidentally omitted a required dependency (and that the fallback builds libqlviewer-qt4 in the source tree).

This PR:
- Fixes the missing dependency in octovis' package.xml (and also changes the style back to build and exec dependencies)
- Also changes the generation of CMake config files etc. to happen in the binary dir instead of in the source directory. This is required on read-only filesystems
- Adds the public link attribute for octovis

@ahornung, could you please make a patch release 1.9.2 after this PR? Thank you :-)