### PR TITLE
Support configurable libdir

### DIFF
--- a/dynamicEDT3D/CMakeLists.txt
+++ b/dynamicEDT3D/CMakeLists.txt
@@ -2,6 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 PROJECT(dynamicEDT3D)
 
 include(CTest)
+include(GNUInstallDirs)
 
 # version (e.g. for packaging)
 set(DYNAMICEDT3D_MAJOR_VERSION 1)
@@ -63,10 +64,10 @@ ADD_SUBDIRECTORY(src)
 
 
 file(GLOB dynamicEDT3D_HDRS ${PROJECT_SOURCE_DIR}/include/dynamicEDT3D/*.h ${PROJECT_SOURCE_DIR}/include/dynamicEDT3D/*.hxx)
-install(FILES ${dynamicEDT3D_HDRS}	DESTINATION include/dynamicEDT3D)
+install(FILES ${dynamicEDT3D_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/dynamicEDT3D")
 
 # Install catkin package.xml, attention package.xml names the catkin package "dynamic_edt_3d", so this is also the location where it needs to be installed to (and not "dynamicEDT3D")
-install(FILES package.xml DESTINATION share/dynamic_edt_3d)
+install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/dynamic_edt_3d")
 
 #TODO: this conflicts with the octomap uninstall
 #it is not only a target name problem, also both will use the same manifest file
@@ -106,7 +107,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   dynamicEDT3DConfig.cmake.in
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/dynamicEDT3D/dynamicEDT3DConfig.cmake"
   PATH_VARS DYNAMICEDT3D_INCLUDE_DIRS DYNAMICEDT3D_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dynamicEDT3D)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/dynamicEDT3D")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/dynamicEDT3D/dynamicEDT3DConfig-version.cmake"
@@ -120,8 +121,8 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
  
 # Create a dynamicEDT3DConfig.cmake file for the use from the install tree
 # and install it
-set(DYNAMICEDT3D_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
-set(DYNAMICEDT3D_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+set(DYNAMICEDT3D_INCLUDE_DIRS "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(DYNAMICEDT3D_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
 #set(DYNAMICEDT3D_CMAKE_DIR "${INSTALL_DATA_DIR}/FooBar/CMake")
 
 set(DYNAMICEDT3D_INCLUDE_TARGETS
@@ -131,7 +132,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   dynamicEDT3DConfig.cmake.in
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig.cmake"
   PATH_VARS DYNAMICEDT3D_INCLUDE_DIRS DYNAMICEDT3D_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dynamicEDT3D)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/dynamicEDT3D")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig-version.cmake"
@@ -141,7 +142,7 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 install(FILES
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig.cmake"
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig-version.cmake" 
-  DESTINATION share/dynamicEDT3D/)
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/dynamicEDT3D")
 
 # Write pkgconfig-file:
 include(InstallPkgConfigFile)

--- a/dynamicEDT3D/CMakeModules/InstallPkgConfigFile.cmake
+++ b/dynamicEDT3D/CMakeModules/InstallPkgConfigFile.cmake
@@ -7,10 +7,10 @@
 #                              [LIBS <lflag> ...]
 #                              [REQUIRES <required-package-name> ...])
 # 
-# Create and install a pkg-config .pc file to CMAKE_INSTALL_PREFIX/lib/pkgconfig
+# Create and install a pkg-config .pc file to CMAKE_INSTALL_LIBDIR/pkgconfig
 #	assuming the following install layout:
-#	       libraries:   CMAKE_INSTALL_PREFIX/lib
-#	       headers  :   CMAKE_INSTALL_PREFIX/include
+#	       libraries:   CMAKE_INSTALL_LIBDIR
+#	       headers  :   CMAKE_INSTALL_INCLUDEDIR
 #
 # example:
 #    add_library(mylib mylib.c)
@@ -63,8 +63,8 @@ function(install_pkg_config_file)
     # write the .pc file out
     file(WRITE ${pc_fname}
         "prefix=${CMAKE_INSTALL_PREFIX}\n"
-        "libdir=\${prefix}/lib\n"
-        "includedir=\${prefix}/include\n"
+        "libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n"
+        "includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}\n"
         "\n"
         "Name: ${pc_name}\n"
         "Description: ${pc_description}\n"
@@ -74,5 +74,5 @@ function(install_pkg_config_file)
         "Cflags: -I\${includedir} ${pc_cflags}\n")
 
     # mark the .pc file for installation to the lib/pkgconfig directory
-    install(FILES ${pc_fname} DESTINATION lib/pkgconfig)    
+    install(FILES ${pc_fname} DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endfunction(install_pkg_config_file)

--- a/dynamicEDT3D/src/CMakeLists.txt
+++ b/dynamicEDT3D/src/CMakeLists.txt
@@ -32,7 +32,7 @@ ADD_SUBDIRECTORY(examples)
 
 install(TARGETS dynamicedt3d dynamicedt3d-static
   EXPORT dynamicEDT3DTargets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-install(EXPORT dynamicEDT3DTargets DESTINATION share/dynamicEDT3D/)
+install(EXPORT dynamicEDT3DTargets DESTINATION "${CMAKE_INSTALL_DATADIR}/dynamicEDT3D")

--- a/octomap/CMakeLists.txt
+++ b/octomap/CMakeLists.txt
@@ -2,6 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 PROJECT( octomap )
 
 include(CTest)
+include(GNUInstallDirs)
 
 # version (e.g. for packaging)
 set(OCTOMAP_MAJOR_VERSION 1)
@@ -55,21 +56,21 @@ LINK_DIRECTORIES(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 # Installation
 
 set(INSTALL_TARGETS_DEFAULT_ARGS
-	RUNTIME DESTINATION bin
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
 ADD_SUBDIRECTORY( src/math )
 ADD_SUBDIRECTORY( src )
 
 file(GLOB octomap_HDRS ${PROJECT_SOURCE_DIR}/include/octomap/*.h ${PROJECT_SOURCE_DIR}/include/octomap/*.hxx)
-install(FILES ${octomap_HDRS}	DESTINATION include/octomap)
+install(FILES ${octomap_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octomap")
 file(GLOB octomap_math_HDRS ${PROJECT_SOURCE_DIR}/include/octomap/math/*.h)
-install(FILES ${octomap_math_HDRS}	DESTINATION include/octomap/math)
+install(FILES ${octomap_math_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octomap/math")
 
 # Install catkin package.xml
-install(FILES package.xml DESTINATION share/octomap)
+install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
 # uninstall target
 configure_file(
@@ -113,7 +114,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   octomap-config.cmake.in
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/octomap/octomap-config.cmake"
   PATH_VARS OCTOMAP_INCLUDE_DIRS OCTOMAP_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/octomap)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/octomap")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/octomap/octomap-config-version.cmake"
@@ -122,8 +123,8 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 
 # Create a octomap-config.cmake file for the use from the install tree
 # and install it
-set(OCTOMAP_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
-set(OCTOMAP_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+set(OCTOMAP_INCLUDE_DIRS "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(OCTOMAP_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
 #set(OCTOMAP_CMAKE_DIR "${INSTALL_DATA_DIR}/FooBar/CMake")
 
 set(OCTOMAP_INCLUDE_TARGETS
@@ -133,7 +134,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   octomap-config.cmake.in
   "${PROJECT_BINARY_DIR}/InstallFiles/octomap-config.cmake"
   PATH_VARS OCTOMAP_INCLUDE_DIRS OCTOMAP_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/octomap)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/octomap")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   ${PROJECT_BINARY_DIR}/InstallFiles/octomap-config-version.cmake
@@ -143,7 +144,7 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 install(FILES
   "${PROJECT_BINARY_DIR}/InstallFiles/octomap-config.cmake"
   "${PROJECT_BINARY_DIR}/InstallFiles/octomap-config-version.cmake" 
-  DESTINATION share/octomap/)
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
 # Write pkgconfig-file:
 include(InstallPkgConfigFile)

--- a/octomap/CMakeModules/InstallPkgConfigFile.cmake
+++ b/octomap/CMakeModules/InstallPkgConfigFile.cmake
@@ -7,10 +7,10 @@
 #                              [LIBS <lflag> ...]
 #                              [REQUIRES <required-package-name> ...])
 # 
-# Create and install a pkg-config .pc file to CMAKE_INSTALL_PREFIX/lib/pkgconfig
+# Create and install a pkg-config .pc file to CMAKE_INSTALL_LIBDIR/pkgconfig
 #	assuming the following install layout:
-#	       libraries:   CMAKE_INSTALL_PREFIX/lib
-#	       headers  :   CMAKE_INSTALL_PREFIX/include
+#	       libraries:   CMAKE_INSTALL_LIBDIR
+#	       headers  :   CMAKE_INSTALL_INCLUDEDIR
 #
 # example:
 #    add_library(mylib mylib.c)
@@ -63,8 +63,8 @@ function(install_pkg_config_file)
     # write the .pc file out
     file(WRITE ${pc_fname}
         "prefix=${CMAKE_INSTALL_PREFIX}\n"
-        "libdir=\${prefix}/lib\n"
-        "includedir=\${prefix}/include\n"
+        "libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n"
+        "includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}\n"
         "\n"
         "Name: ${pc_name}\n"
         "Description: ${pc_description}\n"
@@ -74,5 +74,5 @@ function(install_pkg_config_file)
         "Cflags: -I\${includedir} ${pc_cflags}\n")
 
     # mark the .pc file for installation to the lib/pkgconfig directory
-    install(FILES ${pc_fname} DESTINATION lib/pkgconfig)    
+    install(FILES ${pc_fname} DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endfunction(install_pkg_config_file)

--- a/octomap/src/CMakeLists.txt
+++ b/octomap/src/CMakeLists.txt
@@ -69,10 +69,10 @@ TARGET_LINK_LIBRARIES(octree2pointcloud octomap)
 
 install(TARGETS octomap octomap-static
   EXPORT octomap-targets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-install(EXPORT octomap-targets DESTINATION share/octomap/)
+install(EXPORT octomap-targets DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
 install(TARGETS
 	graph2tree

--- a/octomap/src/math/CMakeLists.txt
+++ b/octomap/src/math/CMakeLists.txt
@@ -24,6 +24,6 @@ export(TARGETS octomath octomath-static
 
 install(TARGETS octomath octomath-static
   EXPORT octomap-targets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )

--- a/octovis/CMakeLists.txt
+++ b/octovis/CMakeLists.txt
@@ -2,6 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
 PROJECT( octovis )
 
 include(CTest)
+include(GNUInstallDirs)
 
 # # version (e.g. for packaging)
 set(OCTOVIS_MAJOR_VERSION 1)
@@ -55,9 +56,9 @@ INCLUDE_DIRECTORIES(BEFORE SYSTEM ${OCTOMAP_INCLUDE_DIRS})
 export(PACKAGE octovis)
 
 set(INSTALL_TARGETS_DEFAULT_ARGS
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
 # Builds the "octovis" viewer based on OpenGL and 
@@ -125,8 +126,8 @@ IF(BUILD_VIEWER)
     
   # Create a octovis-config.cmake file for the use from the install tree
   # and install it
-  set(OCTOVIS_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
-  set(OCTOVIS_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+  set(OCTOVIS_INCLUDE_DIRS "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+  set(OCTOVIS_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
   #set(OCTOMAP_CMAKE_DIR "${INSTALL_DATA_DIR}/FooBar/CMake")
 
   set(OCTOVIS_INCLUDE_TARGETS
@@ -136,7 +137,7 @@ IF(BUILD_VIEWER)
     octovis-config.cmake.in
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config.cmake"
     PATH_VARS OCTOVIS_INCLUDE_DIRS OCTOVIS_LIB_DIR
-    INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/octovis)
+    INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/octovis")
 
   WRITE_BASIC_PACKAGE_VERSION_FILE(
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config-version.cmake"
@@ -146,15 +147,15 @@ IF(BUILD_VIEWER)
   install(FILES
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config.cmake"
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config-version.cmake" 
-    DESTINATION share/octovis/)
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/octovis")
 
   # #installation:
   # # store all header files to install:
   file(GLOB octovis_HDRS  *.h *.hxx *.hpp)
-  install(FILES ${octovis_HDRS} DESTINATION include/octovis)
+  install(FILES ${octovis_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octovis")
 
   # Install catkin package.xml
-  install(FILES package.xml DESTINATION share/octovis)
+  install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/octovis")
   
 ELSE()
     MESSAGE ( "Unfortunately, the viewer (octovis) can not be built because some requirements are missing.")

--- a/octovis/CMakeLists_src.txt
+++ b/octovis/CMakeLists_src.txt
@@ -151,13 +151,13 @@ export(TARGETS octovis octovis-static octovis-shared
 
 install(TARGETS octovis octovis-static octovis-shared
   EXPORT octovis-targets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-install(EXPORT octovis-targets DESTINATION share/octovis/)
+install(EXPORT octovis-targets DESTINATION "${CMAKE_INSTALL_DATADIR}/octovis")
 
 file(GLOB octovis_HDRS ${PROJECT_SOURCE_DIR}/include/octovis/*.h)
 # filter generated headers for GUI:
 list(REMOVE_ITEM octovis_HDRS ${viewer_MOC_HDRS} ${viewer_UIS_H})
-install(FILES ${octovis_HDRS} DESTINATION include/octovis)
+install(FILES ${octovis_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octovis")
 


### PR DESCRIPTION
Still defaults to PREFIX/lib but e.g. Debian or Fedora packagers
can easily set it to lib/x86_64-linux-gnu or lib64 respectively.