### PR TITLE
[octovis] Update dependencies to Qt5

### DIFF
--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -20,12 +20,25 @@
   </export>
       
   <build_depend>octomap</build_depend>
-  <build_depend>libqglviewer-qt4-dev</build_depend>
+
+  <!-- Qt5 -->
+  <build_depend>libqt5-core</build_depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
+
+  <!-- Qt4 -->
+  <!-- <build_depend>libqglviewer-qt4-dev</build_depend>
   <build_depend>libqt4-dev</build_depend>
-  <build_depend>libqt4-opengl-dev</build_depend>
+  <build_depend>libqt4-opengl-dev</build_depend> -->
 
   <exec_depend>octomap</exec_depend>
-  <exec_depend>libqglviewer-qt4</exec_depend>
+
+  <!-- Qt5 -->
+  <exec_depend>libqt5-core</exec_depend>
+  <exec_depend>libqt5-opengl</exec_depend>
+  <exec_depend>libqt5-gui</exec_depend>
+
+  <!-- Qt4 -->
+  <!-- <exec_depend>libqglviewer-qt4</exec_depend>
   <exec_depend>libqtgui4</exec_depend>
-  <exec_depend>libqt4-opengl</exec_depend>
+  <exec_depend>libqt4-opengl</exec_depend> -->
 </package>

--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -22,6 +22,7 @@
   <build_depend>octomap</build_depend>
 
   <!-- Qt5 -->
+  <build_depend>libqglviewer-dev-qt5</build_depend>
   <build_depend>libqt5-core</build_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
 
@@ -33,9 +34,10 @@
   <exec_depend>octomap</exec_depend>
 
   <!-- Qt5 -->
+  <exec_depend>libqglviewer2-qt5</exec_depend>
   <exec_depend>libqt5-core</exec_depend>
-  <exec_depend>libqt5-opengl</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
+  <exec_depend>libqt5-opengl</exec_depend>
 
   <!-- Qt4 -->
   <!-- <exec_depend>libqglviewer-qt4</exec_depend>


### PR DESCRIPTION
Recently, OCTOVIS_QT5 was set to ON by default (cf. #280). This requires updated package dependencies to work on the buildfarm. I am unclear if this will fully work or if we first need to upstream `libqglviewer-qt5` as a rosdep key, and then also add it to `octovis`. With a local `industrial_ci` build, this appeared to work though.