### PR TITLE
Fix children[] array not deleted in deleteNodeRecurs function.

### DIFF
--- a/octomap/include/octomap/OcTreeBaseImpl.hxx
+++ b/octomap/include/octomap/OcTreeBaseImpl.hxx
@@ -706,6 +706,10 @@ namespace octomap {
       this->deleteNodeChild(node, pos);
 
       if (!nodeHasChildren(node))
+        if(node->children != NULL){
+          delete[] node->children;
+          node->children = NULL;
+        }
         return true;
       else{
         node->updateOccupancyChildren(); // TODO: occupancy?


### PR DESCRIPTION
Fix issue where deleteNode children == __null assertion fails due to children[] array not deleted in deleteNodeRecurs function ([https://github.com/OctoMap/octomap/issues/283](url), [https://github.com/OctoMap/octomap/issues/287](url))