### PR TITLE
fix ifstream >> byte with c++17

### DIFF
--- a/octomap/src/binvox2bt.cpp
+++ b/octomap/src/binvox2bt.cpp
@@ -56,9 +56,9 @@
 using namespace std;
 using namespace octomap;
 
-#if __cplusplus < 201500L
+namespace octomap {
  typedef unsigned char byte;
-#endif
+}
 
 int main(int argc, char **argv)
 {
@@ -229,8 +229,8 @@ int main(int argc, char **argv)
         cout.flush();
 
         // read voxel data
-        byte value;
-        byte count;
+        octomap::byte value;
+        octomap::byte count;
         int index = 0;
         int end_index = 0;
         unsigned nr_voxels = 0;

--- a/octomap/src/edit_octree.cpp
+++ b/octomap/src/edit_octree.cpp
@@ -41,9 +41,6 @@
 using namespace std;
 using namespace octomap;
 
-#if __cplusplus < 201500L
-  typedef unsigned char byte;
-#endif
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
std::byte can't be read from a file (no overload of operator >>
available), fall back to typedef'fing it to unsigned char again.

Related: #240