### PR TITLE
fix qmake command to build libQGLViewer with Qt5.

### DIFF
--- a/octovis/CMakeModules/FindQGLViewer.cmake
+++ b/octovis/CMakeModules/FindQGLViewer.cmake
@@ -83,7 +83,7 @@ IF(BUILD_LIB_FROM_SOURCE)
 	MESSAGE(STATUS "\t generating Makefile using qmake") 
 	EXECUTE_PROCESS(
 	  WORKING_DIRECTORY ${QGLVIEWER_BASE_DIR}
-	  COMMAND qmake-qt4
+	  COMMAND qmake
 	  OUTPUT_QUIET
 	  )
       ENDIF(QMAKE-QT4)


### PR DESCRIPTION
just a small fix. There was already an if-else to check if qmake-qt4 is available, but the call in else was still using qmake-qt4 even if not available.