### PR TITLE
Merge devel into ros2 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: cpp
 sudo: required
-dist: trusty
+dist: bionic
 compiler:
   - gcc
   - clang
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libqt4-dev libqt4-opengl-dev libqglviewer-dev  
+  - sudo apt-get install -qq libqglviewer-dev-qt5
 before_script:
 script: ./scripts/travis_build_jobs.sh $VARIANT
 env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # enables -fPIC in applicable compilers
 
 option(BUILD_OCTOVIS_SUBPROJECT "Build targets from subproject octovis" ON)
 option(BUILD_DYNAMICETD3D_SUBPROJECT  "Build targets from subproject dynamicEDT3D" ON)
-option(OCTOVIS_QT5 "Link Octovis against Qt5?" NO)
+option(OCTOVIS_QT5 "Link Octovis against Qt5?" ON)
 
 if(OCTOVIS_QT5)
 	# Compiling against QT5 requires C++11.

--- a/dynamicEDT3D/CMakeLists.txt
+++ b/dynamicEDT3D/CMakeLists.txt
@@ -2,11 +2,12 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 PROJECT(dynamicEDT3D)
 
 include(CTest)
+include(GNUInstallDirs)
 
 # version (e.g. for packaging)
 set(DYNAMICEDT3D_MAJOR_VERSION 1)
 set(DYNAMICEDT3D_MINOR_VERSION 9)
-set(DYNAMICEDT3D_PATCH_VERSION 0)
+set(DYNAMICEDT3D_PATCH_VERSION 5)
 set(DYNAMICEDT3D_VERSION ${DYNAMICEDT3D_MAJOR_VERSION}.${DYNAMICEDT3D_MINOR_VERSION}.${DYNAMICEDT3D_PATCH_VERSION})
 set(DYNAMICEDT3D_SOVERSION ${DYNAMICEDT3D_MAJOR_VERSION}.${DYNAMICEDT3D_MINOR_VERSION})
 
@@ -63,10 +64,10 @@ ADD_SUBDIRECTORY(src)
 
 
 file(GLOB dynamicEDT3D_HDRS ${PROJECT_SOURCE_DIR}/include/dynamicEDT3D/*.h ${PROJECT_SOURCE_DIR}/include/dynamicEDT3D/*.hxx)
-install(FILES ${dynamicEDT3D_HDRS}	DESTINATION include/dynamicEDT3D)
+install(FILES ${dynamicEDT3D_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/dynamicEDT3D")
 
 # Install catkin package.xml, attention package.xml names the catkin package "dynamic_edt_3d", so this is also the location where it needs to be installed to (and not "dynamicEDT3D")
-install(FILES package.xml DESTINATION share/dynamic_edt_3d)
+install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/dynamic_edt_3d")
 
 #TODO: this conflicts with the octomap uninstall
 #it is not only a target name problem, also both will use the same manifest file
@@ -106,7 +107,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   dynamicEDT3DConfig.cmake.in
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/dynamicEDT3D/dynamicEDT3DConfig.cmake"
   PATH_VARS DYNAMICEDT3D_INCLUDE_DIRS DYNAMICEDT3D_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dynamicEDT3D)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/dynamicEDT3D")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/dynamicEDT3D/dynamicEDT3DConfig-version.cmake"
@@ -120,8 +121,8 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
  
 # Create a dynamicEDT3DConfig.cmake file for the use from the install tree
 # and install it
-set(DYNAMICEDT3D_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
-set(DYNAMICEDT3D_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+set(DYNAMICEDT3D_INCLUDE_DIRS "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(DYNAMICEDT3D_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
 #set(DYNAMICEDT3D_CMAKE_DIR "${INSTALL_DATA_DIR}/FooBar/CMake")
 
 set(DYNAMICEDT3D_INCLUDE_TARGETS
@@ -131,7 +132,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   dynamicEDT3DConfig.cmake.in
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig.cmake"
   PATH_VARS DYNAMICEDT3D_INCLUDE_DIRS DYNAMICEDT3D_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dynamicEDT3D)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/dynamicEDT3D")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig-version.cmake"
@@ -141,7 +142,7 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 install(FILES
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig.cmake"
   "${PROJECT_BINARY_DIR}/InstallFiles/dynamicEDT3DConfig-version.cmake" 
-  DESTINATION share/dynamicEDT3D/)
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/dynamicEDT3D")
 
 # Write pkgconfig-file:
 include(InstallPkgConfigFile)

--- a/dynamicEDT3D/CMakeModules/InstallPkgConfigFile.cmake
+++ b/dynamicEDT3D/CMakeModules/InstallPkgConfigFile.cmake
@@ -7,10 +7,10 @@
 #                              [LIBS <lflag> ...]
 #                              [REQUIRES <required-package-name> ...])
 # 
-# Create and install a pkg-config .pc file to CMAKE_INSTALL_PREFIX/lib/pkgconfig
+# Create and install a pkg-config .pc file to CMAKE_INSTALL_LIBDIR/pkgconfig
 #	assuming the following install layout:
-#	       libraries:   CMAKE_INSTALL_PREFIX/lib
-#	       headers  :   CMAKE_INSTALL_PREFIX/include
+#	       libraries:   CMAKE_INSTALL_LIBDIR
+#	       headers  :   CMAKE_INSTALL_INCLUDEDIR
 #
 # example:
 #    add_library(mylib mylib.c)
@@ -63,8 +63,8 @@ function(install_pkg_config_file)
     # write the .pc file out
     file(WRITE ${pc_fname}
         "prefix=${CMAKE_INSTALL_PREFIX}\n"
-        "libdir=\${prefix}/lib\n"
-        "includedir=\${prefix}/include\n"
+        "libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n"
+        "includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}\n"
         "\n"
         "Name: ${pc_name}\n"
         "Description: ${pc_description}\n"
@@ -74,5 +74,5 @@ function(install_pkg_config_file)
         "Cflags: -I\${includedir} ${pc_cflags}\n")
 
     # mark the .pc file for installation to the lib/pkgconfig directory
-    install(FILES ${pc_fname} DESTINATION lib/pkgconfig)    
+    install(FILES ${pc_fname} DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endfunction(install_pkg_config_file)

--- a/dynamicEDT3D/package.xml
+++ b/dynamicEDT3D/package.xml
@@ -1,10 +1,11 @@
 <package format="3">
   <name>dynamic_edt_3d</name>
-  <version>1.9.0</version>
+  <version>1.9.5</version>
   <description> The dynamicEDT3D library implements an inrementally updatable Euclidean distance transform (EDT) in 3D. It comes with a wrapper to use the OctoMap 3D representation and hooks into the change detection of the OctoMap library to propagate changes to the EDT.</description>
 
   <author email="sprunkc@informatik.uni-freiburg.de">Christoph Sprunk</author>
   <maintainer email="sprunkc@informatik.uni-freiburg.de">Christoph Sprunk</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
 
   <url type="website">http://octomap.github.io</url>

--- a/dynamicEDT3D/src/CMakeLists.txt
+++ b/dynamicEDT3D/src/CMakeLists.txt
@@ -32,7 +32,7 @@ ADD_SUBDIRECTORY(examples)
 
 install(TARGETS dynamicedt3d dynamicedt3d-static
   EXPORT dynamicEDT3DTargets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-install(EXPORT dynamicEDT3DTargets DESTINATION share/dynamicEDT3D/)
+install(EXPORT dynamicEDT3DTargets DESTINATION "${CMAKE_INSTALL_DATADIR}/dynamicEDT3D")

--- a/octomap/CHANGELOG.txt
+++ b/octomap/CHANGELOG.txt
@@ -1,3 +1,26 @@
+v1.9.5: 2020-03-25
+==================
+- octovis: Update ROS dependencies to Qt5
+
+v1.9.4: 2020-03-15
+==================
+- octovis: Enable Qt5 by default
+- Support added for configurable libdir for packaging
+- Increased minimum CMake version to 3.0.2
+
+v1.9.3: 2019-12-26
+==================
+- Fixed Wpedantic warnings
+- Removed problematic INSTALL_NAME_DIR (maxOS workaround)
+
+v1.9.2: 2019-11-28
+==================
+- Fixed ROS buildfarm failures for octovis
+
+v1.9.1: 2019-11-23
+==================
+- Improved compatibility with modern compilers and ROS2
+
 v1.9.0: 2017-04-28
 ==================
 - Fixed getUnknownLeafCenters to return true leaf centers (thx to A. Ecins)

--- a/octomap/CMakeLists.txt
+++ b/octomap/CMakeLists.txt
@@ -2,11 +2,12 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 PROJECT( octomap )
 
 include(CTest)
+include(GNUInstallDirs)
 
 # version (e.g. for packaging)
 set(OCTOMAP_MAJOR_VERSION 1)
 set(OCTOMAP_MINOR_VERSION 9)
-set(OCTOMAP_PATCH_VERSION 0)
+set(OCTOMAP_PATCH_VERSION 5)
 set(OCTOMAP_VERSION ${OCTOMAP_MAJOR_VERSION}.${OCTOMAP_MINOR_VERSION}.${OCTOMAP_PATCH_VERSION})
 set(OCTOMAP_SOVERSION ${OCTOMAP_MAJOR_VERSION}.${OCTOMAP_MINOR_VERSION})
 if(COMMAND cmake_policy)
@@ -55,21 +56,21 @@ LINK_DIRECTORIES(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 # Installation
 
 set(INSTALL_TARGETS_DEFAULT_ARGS
-	RUNTIME DESTINATION bin
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
 ADD_SUBDIRECTORY( src/math )
 ADD_SUBDIRECTORY( src )
 
 file(GLOB octomap_HDRS ${PROJECT_SOURCE_DIR}/include/octomap/*.h ${PROJECT_SOURCE_DIR}/include/octomap/*.hxx)
-install(FILES ${octomap_HDRS}	DESTINATION include/octomap)
+install(FILES ${octomap_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octomap")
 file(GLOB octomap_math_HDRS ${PROJECT_SOURCE_DIR}/include/octomap/math/*.h)
-install(FILES ${octomap_math_HDRS}	DESTINATION include/octomap/math)
+install(FILES ${octomap_math_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octomap/math")
 
 # Install catkin package.xml
-install(FILES package.xml DESTINATION share/octomap)
+install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
 # uninstall target
 configure_file(
@@ -113,7 +114,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   octomap-config.cmake.in
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/octomap/octomap-config.cmake"
   PATH_VARS OCTOMAP_INCLUDE_DIRS OCTOMAP_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/octomap)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/octomap")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cmake/octomap/octomap-config-version.cmake"
@@ -122,8 +123,8 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 
 # Create a octomap-config.cmake file for the use from the install tree
 # and install it
-set(OCTOMAP_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
-set(OCTOMAP_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+set(OCTOMAP_INCLUDE_DIRS "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(OCTOMAP_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
 #set(OCTOMAP_CMAKE_DIR "${INSTALL_DATA_DIR}/FooBar/CMake")
 
 set(OCTOMAP_INCLUDE_TARGETS
@@ -133,7 +134,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE(
   octomap-config.cmake.in
   "${PROJECT_BINARY_DIR}/InstallFiles/octomap-config.cmake"
   PATH_VARS OCTOMAP_INCLUDE_DIRS OCTOMAP_LIB_DIR
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/octomap)
+  INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/octomap")
 
 WRITE_BASIC_PACKAGE_VERSION_FILE(
   ${PROJECT_BINARY_DIR}/InstallFiles/octomap-config-version.cmake
@@ -143,7 +144,7 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(
 install(FILES
   "${PROJECT_BINARY_DIR}/InstallFiles/octomap-config.cmake"
   "${PROJECT_BINARY_DIR}/InstallFiles/octomap-config-version.cmake" 
-  DESTINATION share/octomap/)
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
 # Write pkgconfig-file:
 include(InstallPkgConfigFile)

--- a/octomap/CMakeModules/InstallPkgConfigFile.cmake
+++ b/octomap/CMakeModules/InstallPkgConfigFile.cmake
@@ -7,10 +7,10 @@
 #                              [LIBS <lflag> ...]
 #                              [REQUIRES <required-package-name> ...])
 # 
-# Create and install a pkg-config .pc file to CMAKE_INSTALL_PREFIX/lib/pkgconfig
+# Create and install a pkg-config .pc file to CMAKE_INSTALL_LIBDIR/pkgconfig
 #	assuming the following install layout:
-#	       libraries:   CMAKE_INSTALL_PREFIX/lib
-#	       headers  :   CMAKE_INSTALL_PREFIX/include
+#	       libraries:   CMAKE_INSTALL_LIBDIR
+#	       headers  :   CMAKE_INSTALL_INCLUDEDIR
 #
 # example:
 #    add_library(mylib mylib.c)
@@ -63,8 +63,8 @@ function(install_pkg_config_file)
     # write the .pc file out
     file(WRITE ${pc_fname}
         "prefix=${CMAKE_INSTALL_PREFIX}\n"
-        "libdir=\${prefix}/lib\n"
-        "includedir=\${prefix}/include\n"
+        "libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n"
+        "includedir=${CMAKE_INSTALL_FULL_INCLUDEDIR}\n"
         "\n"
         "Name: ${pc_name}\n"
         "Description: ${pc_description}\n"
@@ -74,5 +74,5 @@ function(install_pkg_config_file)
         "Cflags: -I\${includedir} ${pc_cflags}\n")
 
     # mark the .pc file for installation to the lib/pkgconfig directory
-    install(FILES ${pc_fname} DESTINATION lib/pkgconfig)    
+    install(FILES ${pc_fname} DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endfunction(install_pkg_config_file)

--- a/octomap/include/octomap/AbstractOccupancyOcTree.h
+++ b/octomap/include/octomap/AbstractOccupancyOcTree.h
@@ -235,7 +235,7 @@ namespace octomap {
     static const std::string binaryFileHeader;
   };
 
-}; // end namespace
+} // end namespace
 
 
 #endif

--- a/octomap/include/octomap/OcTreeKey.h
+++ b/octomap/include/octomap/OcTreeKey.h
@@ -49,7 +49,7 @@
   #include <tr1/unordered_map>
   namespace octomap {
     namespace unordered_ns = std::tr1;
-  };
+  }
 #else
   #include <unordered_set>
   #include <unordered_map>

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -113,7 +113,7 @@ namespace octomap {
 
 
   template <class NODE>
-  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double maxrange, bool lazy_eval) {
+  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double /* maxrange */, bool lazy_eval) {
     if (pc.size() < 1)
       return;
 

--- a/octomap/package.xml
+++ b/octomap/package.xml
@@ -1,12 +1,13 @@
 <package format="3">
   <name>octomap</name>
-  <version>1.9.0</version>
+  <version>1.9.5</version>
   <description>The OctoMap library implements a 3D occupancy grid mapping approach, providing data structures and mapping algorithms in C++. The map implementation is based on an octree. See
   http://octomap.github.io for details.</description>
 
   <author email="wurm@informatik.uni-freiburg.de">Kai M. Wurm</author>
   <author email="armin@hornung.io">Armin Hornung</author>
   <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
 
   <url type="website">http://octomap.github.io</url>

--- a/octomap/src/CMakeLists.txt
+++ b/octomap/src/CMakeLists.txt
@@ -69,10 +69,10 @@ TARGET_LINK_LIBRARIES(octree2pointcloud octomap)
 
 install(TARGETS octomap octomap-static
   EXPORT octomap-targets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-install(EXPORT octomap-targets DESTINATION share/octomap/)
+install(EXPORT octomap-targets DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
 install(TARGETS
 	graph2tree

--- a/octomap/src/Pointcloud.cpp
+++ b/octomap/src/Pointcloud.cpp
@@ -38,6 +38,9 @@
 
 #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
   #include <algorithm>
+  #if __cplusplus > 199711L
+    #include <random>
+  #endif
 #else
   #include <ext/algorithm>
 #endif
@@ -210,7 +213,13 @@ namespace octomap {
   #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
     samples.reserve(this->size());
     samples.insert(samples.end(), this->begin(), this->end());
-    std::random_shuffle(samples.begin(), samples.end());
+    #if __cplusplus > 199711L
+      std::random_device r;
+      std::mt19937 urbg(r());
+      std::shuffle(samples.begin(), samples.end(), urbg);
+    #else
+      std::random_shuffle(samples.begin(), samples.end());
+    #endif
     samples.resize(num_samples);
   #else
     random_sample_n(begin(), end(), std::back_insert_iterator<point3d_collection>(samples), num_samples);

--- a/octomap/src/binvox2bt.cpp
+++ b/octomap/src/binvox2bt.cpp
@@ -56,7 +56,9 @@
 using namespace std;
 using namespace octomap;
 
-typedef unsigned char byte;
+namespace octomap {
+ typedef unsigned char byte;
+}
 
 int main(int argc, char **argv)
 {
@@ -227,8 +229,8 @@ int main(int argc, char **argv)
         cout.flush();
 
         // read voxel data
-        byte value;
-        byte count;
+        octomap::byte value;
+        octomap::byte count;
         int index = 0;
         int end_index = 0;
         unsigned nr_voxels = 0;

--- a/octomap/src/edit_octree.cpp
+++ b/octomap/src/edit_octree.cpp
@@ -41,7 +41,6 @@
 using namespace std;
 using namespace octomap;
 
-typedef unsigned char byte;
 
 int main(int argc, char **argv)
 {

--- a/octomap/src/math/CMakeLists.txt
+++ b/octomap/src/math/CMakeLists.txt
@@ -10,9 +10,7 @@ ADD_LIBRARY( octomath SHARED ${octomath_SRCS})
 SET_TARGET_PROPERTIES( octomath PROPERTIES
   VERSION ${OCTOMAP_VERSION}
   SOVERSION ${OCTOMAP_SOVERSION}
-  INSTALL_NAME_DIR ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}   # this seems to be necessary for MacOS X
 )
-# INSTALL_NAME_DIR seems to be necessary for MacOS X
 
 ADD_LIBRARY( octomath-static STATIC ${octomath_SRCS})
 SET_TARGET_PROPERTIES(octomath-static PROPERTIES OUTPUT_NAME "octomath")
@@ -26,6 +24,6 @@ export(TARGETS octomath octomath-static
 
 install(TARGETS octomath octomath-static
   EXPORT octomap-targets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )

--- a/octovis/CMakeLists.txt
+++ b/octovis/CMakeLists.txt
@@ -2,11 +2,12 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 PROJECT( octovis )
 
 include(CTest)
+include(GNUInstallDirs)
 
 # # version (e.g. for packaging)
 set(OCTOVIS_MAJOR_VERSION 1)
 set(OCTOVIS_MINOR_VERSION 9)
-set(OCTOVIS_PATCH_VERSION 0)
+set(OCTOVIS_PATCH_VERSION 5)
 set(OCTOVIS_VERSION ${OCTOVIS_MAJOR_VERSION}.${OCTOVIS_MINOR_VERSION}.${OCTOVIS_PATCH_VERSION})
 set(OCTOVIS_SOVERSION ${OCTOVIS_MAJOR_VERSION}.${OCTOVIS_MINOR_VERSION})
 # get rid of a useless warning:
@@ -55,14 +56,16 @@ INCLUDE_DIRECTORIES(BEFORE SYSTEM ${OCTOMAP_INCLUDE_DIRS})
 export(PACKAGE octovis)
 
 set(INSTALL_TARGETS_DEFAULT_ARGS
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
 # Builds the "octovis" viewer based on OpenGL and 
 # libQGLViewer, if dependencies available
 SET( BUILD_VIEWER 0)
+
+option(OCTOVIS_QT5 "Link Octovis against Qt5?" ON)
 
 # Look for required libraries:
 FIND_PACKAGE(OpenGL)
@@ -125,8 +128,8 @@ IF(BUILD_VIEWER)
     
   # Create a octovis-config.cmake file for the use from the install tree
   # and install it
-  set(OCTOVIS_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
-  set(OCTOVIS_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+  set(OCTOVIS_INCLUDE_DIRS "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+  set(OCTOVIS_LIB_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
   #set(OCTOMAP_CMAKE_DIR "${INSTALL_DATA_DIR}/FooBar/CMake")
 
   set(OCTOVIS_INCLUDE_TARGETS
@@ -136,7 +139,7 @@ IF(BUILD_VIEWER)
     octovis-config.cmake.in
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config.cmake"
     PATH_VARS OCTOVIS_INCLUDE_DIRS OCTOVIS_LIB_DIR
-    INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/octovis)
+    INSTALL_DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/octovis")
 
   WRITE_BASIC_PACKAGE_VERSION_FILE(
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config-version.cmake"
@@ -146,15 +149,15 @@ IF(BUILD_VIEWER)
   install(FILES
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config.cmake"
     "${PROJECT_BINARY_DIR}/InstallFiles/octovis-config-version.cmake" 
-    DESTINATION share/octovis/)
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/octovis")
 
   # #installation:
   # # store all header files to install:
   file(GLOB octovis_HDRS  *.h *.hxx *.hpp)
-  install(FILES ${octovis_HDRS} DESTINATION include/octovis)
+  install(FILES ${octovis_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octovis")
 
   # Install catkin package.xml
-  install(FILES package.xml DESTINATION share/octovis)
+  install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/octovis")
   
 ELSE()
     MESSAGE ( "Unfortunately, the viewer (octovis) can not be built because some requirements are missing.")

--- a/octovis/CMakeLists_src.txt
+++ b/octovis/CMakeLists_src.txt
@@ -151,13 +151,13 @@ export(TARGETS octovis octovis-static octovis-shared
 
 install(TARGETS octovis octovis-static octovis-shared
   EXPORT octovis-targets
-  INCLUDES DESTINATION include
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-install(EXPORT octovis-targets DESTINATION share/octovis/)
+install(EXPORT octovis-targets DESTINATION "${CMAKE_INSTALL_DATADIR}/octovis")
 
 file(GLOB octovis_HDRS ${PROJECT_SOURCE_DIR}/include/octovis/*.h)
 # filter generated headers for GUI:
 list(REMOVE_ITEM octovis_HDRS ${viewer_MOC_HDRS} ${viewer_UIS_H})
-install(FILES ${octovis_HDRS} DESTINATION include/octovis)
+install(FILES ${octovis_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octovis")
 

--- a/octovis/CMakeModules/CompilerSettings.cmake
+++ b/octovis/CMakeModules/CompilerSettings.cmake
@@ -21,8 +21,6 @@ IF (CMAKE_COMPILER_IS_GNUCC)
   SET (CMAKE_CXX_FLAGS_RELEASE "-O3 -funroll-loops -DNDEBUG") #sse3 disabled for compatibility
 #  SET (CMAKE_CXX_FLAGS_RELEASE "-O3 -funroll-loops -DNDEBUG -msse3 -mssse3")
   SET (CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-  # Shared object compilation under 64bit (vtable)
-  ADD_DEFINITIONS(-fPIC)  
   # IF(OCTOMAP_OMP)
   #   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fopenmp")
   #   SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -fopenmp")
@@ -35,6 +33,9 @@ set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# enables -fPIC in applicable compilers
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # no prefix needed for python modules
 set(CMAKE_SHARED_MODULE_PREFIX "")

--- a/octovis/CMakeModules/FindQGLViewer.cmake
+++ b/octovis/CMakeModules/FindQGLViewer.cmake
@@ -1,5 +1,5 @@
 # Find QGLViewer library
-# Looks for a system-wide version of libQGLViewer (qglviewer-qt4 in Ubuntu).
+# Looks for a system-wide version of libQGLViewer (qglviewer-qt4 or 5 in Ubuntu).
 # If none is found, it builds and uses the local copy in "extern"
 #
 # Many thanks to L. Ott for assistance!
@@ -23,7 +23,11 @@ FIND_PATH( QGLViewer_INCLUDE_DIR qglviewer.h
     ${QGLVIEWER_BASE_DIR}
 )
 
-FIND_LIBRARY( QGLViewer_LIBRARY_DIR_UBUNTU NAMES qglviewer-qt4 QGLViewer-qt4)
+IF( QT4_FOUND )
+    FIND_LIBRARY( QGLViewer_LIBRARY_DIR_UBUNTU NAMES qglviewer-qt4 QGLViewer-qt4)
+ELSE()
+    FIND_LIBRARY( QGLViewer_LIBRARY_DIR_UBUNTU NAMES qglviewer-qt5 QGLViewer-qt5)
+ENDIF()
 FIND_LIBRARY( QGLViewer_LIBRARY_DIR_WINDOWS QGLViewer2 ${QGLVIEWER_BASE_DIR})
 FIND_LIBRARY( QGLViewer_LIBRARY_DIR_OTHER QGLViewer ${QGLVIEWER_BASE_DIR})
 
@@ -79,7 +83,7 @@ IF(BUILD_LIB_FROM_SOURCE)
 	MESSAGE(STATUS "\t generating Makefile using qmake") 
 	EXECUTE_PROCESS(
 	  WORKING_DIRECTORY ${QGLVIEWER_BASE_DIR}
-	  COMMAND qmake-qt4
+	  COMMAND qmake
 	  OUTPUT_QUIET
 	  )
       ENDIF(QMAKE-QT4)

--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -1,26 +1,46 @@
 <package format="3">
   <name>octovis</name>
-  <version>1.9.0</version>
+  <version>1.9.5</version>
   <description>octovis is visualization tool for the OctoMap library based on Qt and libQGLViewer. See
   http://octomap.github.io for details.</description>
 
   <author email="wurm@informatik.uni-freiburg.de">Kai M. Wurm</author>
   <author email="armin@hornung.io">Armin Hornung</author>
   <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>GPLv2</license>
 
   <url type="website">http://octomap.github.io</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+      
+  <build_depend>octomap</build_depend>
 
-  <depend>octomap</depend>
-  <depend>libqglviewer-qt4-dev</depend>
-  <depend>libqt4-dev</depend>
-  <depend>libqt4-opengl-dev</depend>
+  <!-- Qt5 -->
+  <build_depend>libqglviewer-dev-qt5</build_depend>
+  <build_depend>libqt5-core</build_depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
+
+  <!-- Qt4 -->
+  <!-- <build_depend>libqglviewer-qt4-dev</build_depend>
+  <build_depend>libqt4-dev</build_depend>
+  <build_depend>libqt4-opengl-dev</build_depend> -->
+
+  <exec_depend>octomap</exec_depend>
+
+  <!-- Qt5 -->
+  <exec_depend>libqglviewer2-qt5</exec_depend>
+  <exec_depend>libqt5-core</exec_depend>
+  <exec_depend>libqt5-gui</exec_depend>
+  <exec_depend>libqt5-opengl</exec_depend>
+
+  <!-- Qt4 -->
+  <!-- <exec_depend>libqglviewer-qt4</exec_depend>
+  <exec_depend>libqtgui4</exec_depend>
+  <exec_depend>libqt4-opengl</exec_depend> -->
 
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -286,7 +286,7 @@ void ViewerGui::showOcTree() {
   m_mapSizeStatus->setText(size);
   //}
 
-  m_glwidget->updateGL();
+  m_glwidget->update();
 
   // generate cubes -> display
   // timeval start;
@@ -299,7 +299,7 @@ void ViewerGui::showOcTree() {
   //    gettimeofday(&stop, NULL);  // stop timer
   //    double time_to_generate = (stop.tv_sec - start.tv_sec) + 1.0e-6 *(stop.tv_usec - start.tv_usec);
   //    fprintf(stderr, "setOcTree took %f sec\n", time_to_generate);
-  m_glwidget->updateGL();
+  m_glwidget->update();
 }
 
 
@@ -983,7 +983,7 @@ void ViewerGui::on_actionSelection_box_toggled(bool checked){
   m_glwidget->enableSelectionBox(checked);
 
 
-  m_glwidget->updateGL();
+  m_glwidget->update();
 }
 
 void ViewerGui::on_actionHeight_map_toggled(bool checked){
@@ -1040,7 +1040,7 @@ void ViewerGui::on_actionAxes_toggled(bool checked){
       it != m_octrees.end(); ++it) {
     it->second.octree_drawer->enableAxes(checked);
   }
-  m_glwidget->updateGL();
+  m_glwidget->update();
 }
 
 void ViewerGui::on_actionHideBackground_toggled(bool checked) {
@@ -1048,7 +1048,7 @@ void ViewerGui::on_actionHideBackground_toggled(bool checked) {
   if (getOctreeRecord(DEFAULT_OCTREE_ID, r)) {
     if (checked) m_glwidget->removeSceneObject(r->octree_drawer);
     else         m_glwidget->addSceneObject(r->octree_drawer);
-    m_glwidget->updateGL();
+    m_glwidget->update();
   }
 }
 
@@ -1142,7 +1142,7 @@ void ViewerGui::on_actionOctree_cells_toggled(bool enabled) {
       it != m_octrees.end(); ++it) {
     it->second.octree_drawer->enableOcTreeCells(enabled);
   }
-  m_glwidget->updateGL();
+  m_glwidget->update();
 }
 
 void ViewerGui::on_actionOctree_structure_toggled(bool enabled) {
@@ -1150,7 +1150,7 @@ void ViewerGui::on_actionOctree_structure_toggled(bool enabled) {
       it != m_octrees.end(); ++it) {
     it->second.octree_drawer->enableOcTree(enabled);
   }
-  m_glwidget->updateGL();
+  m_glwidget->update();
 }
 
 void ViewerGui::on_actionFree_toggled(bool enabled) {
@@ -1158,7 +1158,7 @@ void ViewerGui::on_actionFree_toggled(bool enabled) {
       it != m_octrees.end(); ++it) {
     it->second.octree_drawer->enableFreespace(enabled);
   }
-  m_glwidget->updateGL();
+  m_glwidget->update();
 
 }
 
@@ -1176,24 +1176,21 @@ void ViewerGui::on_actionSelected_toggled(bool enabled) {
   //   } else{
   //     m_octreeDrawer->clearOcTreeSelection();
   //   }
-  //   m_glwidget->updateGL();
+  //   m_glwidget->update();
   // }
 }
 
 
 void ViewerGui::on_action_bg_black_triggered() {
   m_glwidget->setBackgroundColor( QColor(0,0,0) );
-  m_glwidget->qglClearColor( m_glwidget->backgroundColor() );
 }
 
 void ViewerGui::on_action_bg_white_triggered() {
   m_glwidget->setBackgroundColor( QColor(255,255,255) );
-  m_glwidget->qglClearColor( m_glwidget->backgroundColor() );
 }
 
 void ViewerGui::on_action_bg_gray_triggered() {
   m_glwidget->setBackgroundColor( QColor(117,117,117) );
-  m_glwidget->qglClearColor( m_glwidget->backgroundColor() );
 }
 
 void ViewerGui::on_savecampose_triggered() {

--- a/octovis/src/ViewerWidget.cpp
+++ b/octovis/src/ViewerWidget.cpp
@@ -67,13 +67,12 @@ void ViewerWidget::init() {
 
   // background color defaults to white
   this->setBackgroundColor( QColor(255,255,255) );
-  this->qglClearColor( this->backgroundColor() );
 }
 
 void ViewerWidget::resetView(){
   this->camera()->setOrientation((float) -M_PI_2, (float) M_PI_2);
   this->showEntireScene();
-  updateGL();
+  update();
 }
 
 
@@ -98,7 +97,7 @@ void ViewerWidget::enableHeightColorMode (bool enabled) {
   for(std::vector<SceneObject*>::iterator it = m_sceneObjects.begin(); it != m_sceneObjects.end(); it++) {
     (*it)->enableHeightColorMode(enabled);
   }
-  updateGL();
+  update();
 }
 
 void ViewerWidget::enablePrintoutMode(bool enabled) {
@@ -106,7 +105,7 @@ void ViewerWidget::enablePrintoutMode(bool enabled) {
   for(std::vector<SceneObject*>::iterator it = m_sceneObjects.begin(); it != m_sceneObjects.end(); it++) {
     (*it)->enablePrintoutMode(enabled);
   }
-  updateGL();
+  update();
 }
 
 void ViewerWidget::enableSemanticColoring (bool enabled) {
@@ -114,12 +113,12 @@ void ViewerWidget::enableSemanticColoring (bool enabled) {
   for(std::vector<SceneObject*>::iterator it = m_sceneObjects.begin(); it != m_sceneObjects.end(); it++) {
     (*it)->enableSemanticColoring(enabled);
   }
-  updateGL();
+  update();
 }
 
 void ViewerWidget::enableSelectionBox(bool enabled) {
   m_drawSelectionBox = enabled;
-  updateGL();
+  update();
 }
 
 
@@ -145,7 +144,7 @@ void ViewerWidget::setCamPosition(double x, double y, double z, double lookX, do
   camera()->setPosition(qglviewer::Vec(x, y, z));
   camera()->lookAt(qglviewer::Vec(lookX, lookY, lookZ));
   camera()->setUpVector(qglviewer::Vec(0.0, 0.0, 1.0));
-  updateGL();
+  update();
 }
 
 void ViewerWidget::setCamPose(const octomath::Pose6D& pose){
@@ -161,12 +160,12 @@ void ViewerWidget::jumpToCamFrame(int id, int frame) {
   } else {
     std::cerr << "Error: Could not jump to frame " << frame << " of " << kfi->numberOfKeyFrames() << std::endl;
   }
-  updateGL();
+  update();
 }
 
 void ViewerWidget::deleteCameraPath(int id) {
   if(camera()->keyFrameInterpolator(id)) {
-    disconnect(camera()->keyFrameInterpolator(id), SIGNAL(interpolated()), this, SLOT(updateGL()));
+    disconnect(camera()->keyFrameInterpolator(id), SIGNAL(interpolated()), this, SLOT(update()));
     disconnect(camera()->keyFrameInterpolator(id), SIGNAL(interpolated()), this, SLOT(cameraPathInterpolated()));
     disconnect(camera()->keyFrameInterpolator(id), SIGNAL(endReached()), this, SLOT(cameraPathFinished()));
     camera()->deletePath(id);
@@ -243,7 +242,7 @@ void ViewerWidget::playCameraPath(int id, int start_frame) {
     m_current_camera_frame = start_frame;
     kfi->setInterpolationTime(kfi->keyFrameTime(start_frame));
     std::cout << "Playing path of length " << kfi->numberOfKeyFrames() << ", start time " << kfi->keyFrameTime(start_frame) << std::endl;
-    connect(kfi, SIGNAL(interpolated()), this, SLOT(updateGL()));
+    connect(kfi, SIGNAL(interpolated()), this, SLOT(update()));
     connect(kfi, SIGNAL(interpolated()), this, SLOT(cameraPathInterpolated()));
     connect(kfi, SIGNAL(endReached()), this, SLOT(cameraPathFinished()));
     kfi->startInterpolation();
@@ -252,7 +251,7 @@ void ViewerWidget::playCameraPath(int id, int start_frame) {
 
 void ViewerWidget::stopCameraPath(int id) {
   if(camera()->keyFrameInterpolator(id) && camera()->keyFrameInterpolator(id)->interpolationIsStarted()) {
-    disconnect(camera()->keyFrameInterpolator(id), SIGNAL(interpolated()), this, SLOT(updateGL()));
+    disconnect(camera()->keyFrameInterpolator(id), SIGNAL(interpolated()), this, SLOT(update()));
     disconnect(camera()->keyFrameInterpolator(id), SIGNAL(interpolated()), this, SLOT(cameraPathInterpolated()));
     disconnect(camera()->keyFrameInterpolator(id), SIGNAL(endReached()), this, SLOT(cameraPathFinished()));
     camera()->keyFrameInterpolator(id)->stopInterpolation();
@@ -261,7 +260,7 @@ void ViewerWidget::stopCameraPath(int id) {
 
 void ViewerWidget::cameraPathFinished() {
   if(camera()->keyFrameInterpolator(m_current_camera_path)) {
-    disconnect(camera()->keyFrameInterpolator(m_current_camera_path), SIGNAL(interpolated()), this, SLOT(updateGL()));
+    disconnect(camera()->keyFrameInterpolator(m_current_camera_path), SIGNAL(interpolated()), this, SLOT(update()));
     disconnect(camera()->keyFrameInterpolator(m_current_camera_path), SIGNAL(interpolated()), this, SLOT(cameraPathInterpolated()));
     disconnect(camera()->keyFrameInterpolator(m_current_camera_path), SIGNAL(endReached()), this, SLOT(cameraPathFinished()));
     emit cameraPathStopped(m_current_camera_path);
@@ -292,7 +291,7 @@ void ViewerWidget::setSceneBoundingBox(const qglviewer::Vec& min, const qglviewe
 void ViewerWidget::addSceneObject(SceneObject* obj){
   assert (obj);
   m_sceneObjects.push_back(obj);
-  updateGL();
+  update();
 }
 
 void ViewerWidget::removeSceneObject(SceneObject* obj){
@@ -304,7 +303,7 @@ void ViewerWidget::removeSceneObject(SceneObject* obj){
     else
       ++it;
   }
-  updateGL();
+  update();
 }
 
 void ViewerWidget::clearAll(){
@@ -364,7 +363,6 @@ void ViewerWidget::postDraw(){
   glPushAttrib(GL_ALL_ATTRIB_BITS);
 
   glDisable(GL_COLOR_MATERIAL);
-  qglColor(foregroundColor());
 
   if (gridIsDrawn()){
     glLineWidth(1.0);


### PR DESCRIPTION
Looks like the ros2 branch is lagging a bit behind devel. I've just resolved the merge conflict between the cmake version bumps in ros2 and the qt5 package.xml depends from devel. It doesn't look like ament is being used, so I'm not sure why these are two different branches to begin with, given that `ament_target_dependencies` still doesn't seem to work with this package and headers must be manually included for downstream packages.

Related: https://github.com/ros-planning/geometric_shapes/pull/154


cc @mikaelarguedas