### PR TITLE
REP-136 compliance and compatibility with ROS1 & ROS2 using single branch

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -13,13 +13,11 @@ jobs:
         env:
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: noetic}
-          - {ROS_DISTRO: foxy}
-          - {ROS_DISTRO: rolling}
+          - {ROS_DISTRO: foxy, PRERELEASE: true}
+          - {ROS_DISTRO: rolling, PRERELEASE: true}
     env:
       CCACHE_DIR: /github/home/.ccache # Enable ccache
-      PRERELEASE: true # always run the prerelease tests
       BUILDER: colcon
-      # CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/dynamicEDT3D/CMakeLists.txt
+++ b/dynamicEDT3D/CMakeLists.txt
@@ -69,6 +69,10 @@ install(FILES ${dynamicEDT3D_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/dyna
 # Install catkin package.xml, attention package.xml names the catkin package "dynamic_edt_3d", so this is also the location where it needs to be installed to (and not "dynamicEDT3D")
 install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/dynamic_edt_3d")
 
+# Allows Colcon to find non-Ament packages when using workspace underlays
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+
 #TODO: this conflicts with the octomap uninstall
 #it is not only a target name problem, also both will use the same manifest file
 #in the same binary directory

--- a/dynamicEDT3D/package.xml
+++ b/dynamicEDT3D/package.xml
@@ -1,19 +1,24 @@
-<package format="2">
+<package format="3">
   <name>dynamic_edt_3d</name>
   <version>1.9.6</version>
   <description> The dynamicEDT3D library implements an inrementally updatable Euclidean distance transform (EDT) in 3D. It comes with a wrapper to use the OctoMap 3D representation and hooks into the change detection of the OctoMap library to propagate changes to the EDT.</description>
 
   <author email="sprunkc@informatik.uni-freiburg.de">Christoph Sprunk</author>
   <maintainer email="sprunkc@informatik.uni-freiburg.de">Christoph Sprunk</maintainer>
-  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
+  <maintainer email="opensource@wolfgangmerkt.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
 
   <url type="website">http://octomap.github.io</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
 
   <depend>octomap</depend>
-  <buildtool_depend>cmake</buildtool_depend>
 
+  <!-- The following tags are recommended by REP-136 -->
+  <exec_depend>catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
+
+  <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/dynamicEDT3D/package.xml
+++ b/dynamicEDT3D/package.xml
@@ -14,7 +14,6 @@
   <depend>octomap</depend>
 
   <!-- The following tags are recommended by REP-136 -->
-  <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 

--- a/octomap/CMakeLists.txt
+++ b/octomap/CMakeLists.txt
@@ -69,7 +69,7 @@ install(FILES ${octomap_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octomap")
 file(GLOB octomap_math_HDRS ${PROJECT_SOURCE_DIR}/include/octomap/math/*.h)
 install(FILES ${octomap_math_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octomap/math")
 
-# Install catkin package.xml
+# Install package.xml (catkin/ament/rosdep)
 install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
 # uninstall target

--- a/octomap/CMakeLists.txt
+++ b/octomap/CMakeLists.txt
@@ -72,6 +72,10 @@ install(FILES ${octomap_math_HDRS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/octo
 # Install package.xml (catkin/ament/rosdep)
 install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/octomap")
 
+# Allows Colcon to find non-Ament packages when using workspace underlays
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+
 # uninstall target
 configure_file(
     "${PROJECT_SOURCE_DIR}/CMakeModules/CMakeUninstall.cmake.in"

--- a/octomap/package.xml
+++ b/octomap/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>octomap</name>
   <version>1.9.6</version>
   <description>The OctoMap library implements a 3D occupancy grid mapping approach, providing data structures and mapping algorithms in C++. The map implementation is based on an octree. See
@@ -7,14 +7,18 @@
   <author email="wurm@informatik.uni-freiburg.de">Kai M. Wurm</author>
   <author email="armin@hornung.io">Armin Hornung</author>
   <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
-  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
+  <maintainer email="opensource@wolfgangmerkt.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
 
   <url type="website">http://octomap.github.io</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
 
-  <buildtool_depend>cmake</buildtool_depend>
+  <!-- The following tags are recommended by REP-136 -->
+  <exec_depend>catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 
+  <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/octomap/package.xml
+++ b/octomap/package.xml
@@ -14,7 +14,6 @@
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
 
   <!-- The following tags are recommended by REP-136 -->
-  <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 

--- a/octovis/CMakeLists.txt
+++ b/octovis/CMakeLists.txt
@@ -158,6 +158,10 @@ IF(BUILD_VIEWER)
 
   # Install catkin package.xml
   install(FILES package.xml DESTINATION "${CMAKE_INSTALL_DATADIR}/octovis")
+
+  # Allows Colcon to find non-Ament packages when using workspace underlays
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
   
 ELSE()
     MESSAGE ( "Unfortunately, the viewer (octovis) can not be built because some requirements are missing.")

--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>octovis</name>
   <version>1.9.6</version>
   <description>octovis is visualization tool for the OctoMap library based on Qt and libQGLViewer. See
@@ -7,14 +7,18 @@
   <author email="wurm@informatik.uni-freiburg.de">Kai M. Wurm</author>
   <author email="armin@hornung.io">Armin Hornung</author>
   <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
-  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
+  <maintainer email="opensource@wolfgangmerkt.com">Wolfgang Merkt</maintainer>
   <license>GPLv2</license>
 
   <url type="website">http://octomap.github.io</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
 
+  <!-- The following tags are recommended by REP-136 -->
+  <exec_depend>catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
+
   <buildtool_depend>cmake</buildtool_depend>
-  
   <export>
     <build_type>cmake</build_type>
   </export>

--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -14,7 +14,6 @@
   <url type="bugtracker">https://github.com/OctoMap/octomap/issues</url>
 
   <!-- The following tags are recommended by REP-136 -->
-  <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 


### PR DESCRIPTION
In this PR, an exec_dependency on either `catkin` or `ament_cmake` is added per REP-136. The package format is updated to v3 to make use of `condition` arguments. This allows to only maintain a single `devel` branch and effectively deprecate `ros2` going forward. ROS1 and ROS2 can now use `devel`.

@ruffsl @mikaelarguedas can you please test if this works for you?

Alternative to #303