### PR TITLE
Add GitHub Actions CI based on ROS-Industrial CI

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -14,6 +14,8 @@ jobs:
           - {ROS_DISTRO: kinetic}
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: noetic}
+          - {ROS_DISTRO: foxy}
+          - {ROS_DISTRO: rolling}
     env:
       CCACHE_DIR: /github/home/.ccache # Enable ccache
       PRERELEASE: true # always run the prerelease tests

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: kinetic}
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: noetic}
           - {ROS_DISTRO: foxy}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       CCACHE_DIR: /github/home/.ccache # Enable ccache
       PRERELEASE: true # always run the prerelease tests
+      BUILDER: colcon
       # CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -1,0 +1,31 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: CI
+
+# This determines when this workflow is run
+on: [push, pull_request] # on all pushes and PRs
+
+jobs:
+  CI:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: kinetic}
+          - {ROS_DISTRO: melodic}
+          - {ROS_DISTRO: noetic}
+    env:
+      CCACHE_DIR: /github/home/.ccache # Enable ccache
+      PRERELEASE: true # always run the prerelease tests
+      # CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # This step will fetch/store the directory used by ccache before/after the ci run
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
+      # Run industrial_ci
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{ matrix.env }}


### PR DESCRIPTION
Adds an additional CI using GitHub Actions based on the ROS-Industrial CI. It's configured to run the prerelease checks by default. This can help spot issues for releasing OctoMap into the different ROS distros.

Example build: https://github.com/wxmerkt/octomap/runs/1717836573