### PR TITLE
Use explicit casting to prevent implicit sign conversion

### DIFF
--- a/octomap/include/octomap/OcTreeBaseImpl.hxx
+++ b/octomap/include/octomap/OcTreeBaseImpl.hxx
@@ -1057,7 +1057,7 @@ namespace octomap {
     float step_size = this->resolution * pow(2, tree_depth-depth);
     for (int i=0;i<3;++i) {
       diff[i] = pmax_clamped(i) - pmin_clamped(i);
-      steps[i] = floor(diff[i] / step_size);
+      steps[i] = static_cast<unsigned int>(floor(diff[i] / step_size));
       //      std::cout << "bbx " << i << " size: " << diff[i] << " " << steps[i] << " steps\n";
     }
 

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -784,7 +784,7 @@ namespace octomap {
     // Line dot normal will be zero if they are parallel, in which case no intersection can be the entry one
     // if there is an intersection does it occur in the bounded plane of the voxel
     // if yes keep only the closest (smallest distance to sensor origin).
-    if(static_cast<bool>(lineDotNormal = normalX.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if((static_cast<bool>(lineDotNormal = normalX.dot(direction)))){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointXNeg - origin).dot(normalX) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(1) < (pointYNeg(1) - 1e-6) || intersect(1) > (pointYPos(1) + 1e-6) ||
@@ -802,7 +802,7 @@ namespace octomap {
       }
     }
 
-    if(static_cast<bool>(lineDotNormal = normalY.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if((static_cast<bool>(lineDotNormal = normalY.dot(direction)))){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointYNeg - origin).dot(normalY) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(0) < (pointXNeg(0) - 1e-6) || intersect(0) > (pointXPos(0) + 1e-6) ||
@@ -820,7 +820,7 @@ namespace octomap {
       }
     }
 
-    if(static_cast<bool>(lineDotNormal = normalZ.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if((static_cast<bool>(lineDotNormal = normalZ.dot(direction)))){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointZNeg - origin).dot(normalZ) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(0) < (pointXNeg(0) - 1e-6) || intersect(0) > (pointXPos(0) + 1e-6) ||

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -784,7 +784,7 @@ namespace octomap {
     // Line dot normal will be zero if they are parallel, in which case no intersection can be the entry one
     // if there is an intersection does it occur in the bounded plane of the voxel
     // if yes keep only the closest (smallest distance to sensor origin).
-    if((lineDotNormal = normalX.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if(static_cast<bool>(lineDotNormal = normalX.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointXNeg - origin).dot(normalX) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(1) < (pointYNeg(1) - 1e-6) || intersect(1) > (pointYPos(1) + 1e-6) ||
@@ -802,7 +802,7 @@ namespace octomap {
       }
     }
 
-    if((lineDotNormal = normalY.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if(static_cast<bool>(lineDotNormal = normalY.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointYNeg - origin).dot(normalY) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(0) < (pointXNeg(0) - 1e-6) || intersect(0) > (pointXPos(0) + 1e-6) ||
@@ -820,7 +820,7 @@ namespace octomap {
       }
     }
 
-    if((lineDotNormal = normalZ.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if(static_cast<bool>(lineDotNormal = normalZ.dot(direction))){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointZNeg - origin).dot(normalZ) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(0) < (pointXNeg(0) - 1e-6) || intersect(0) > (pointXPos(0) + 1e-6) ||

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -784,7 +784,7 @@ namespace octomap {
     // Line dot normal will be zero if they are parallel, in which case no intersection can be the entry one
     // if there is an intersection does it occur in the bounded plane of the voxel
     // if yes keep only the closest (smallest distance to sensor origin).
-    if((static_cast<bool>(lineDotNormal = normalX.dot(direction)))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if((lineDotNormal = normalX.dot(direction)) != 0.0){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointXNeg - origin).dot(normalX) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(1) < (pointYNeg(1) - 1e-6) || intersect(1) > (pointYPos(1) + 1e-6) ||
@@ -802,7 +802,7 @@ namespace octomap {
       }
     }
 
-    if((static_cast<bool>(lineDotNormal = normalY.dot(direction)))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if((lineDotNormal = normalY.dot(direction)) != 0.0){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointYNeg - origin).dot(normalY) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(0) < (pointXNeg(0) - 1e-6) || intersect(0) > (pointXPos(0) + 1e-6) ||
@@ -820,7 +820,7 @@ namespace octomap {
       }
     }
 
-    if((static_cast<bool>(lineDotNormal = normalZ.dot(direction)))){   // Ensure lineDotNormal is non-zero (assign and test)
+    if((lineDotNormal = normalZ.dot(direction)) != 0.0){   // Ensure lineDotNormal is non-zero (assign and test)
       d = (pointZNeg - origin).dot(normalZ) / lineDotNormal;
       intersect = direction * float(d) + origin;
       if(!(intersect(0) < (pointXNeg(0) - 1e-6) || intersect(0) > (pointXPos(0) + 1e-6) ||
@@ -839,7 +839,7 @@ namespace octomap {
     }
 
     // Substract (add) a fraction to ensure no ambiguity on the starting voxel
-    // Don't start on a bondary.
+    // Don't start on a boundary.
     if(found)
       intersection = direction * float(outD + delta) + origin;
 


### PR DESCRIPTION
Using explicit casting fixes compiler warnings