### PR TITLE
insertPointCloudRays improvement

### DIFF
--- a/octomap/include/octomap/OccupancyOcTreeBase.h
+++ b/octomap/include/octomap/OccupancyOcTreeBase.h
@@ -132,6 +132,11 @@ namespace octomap {
     virtual void insertPointCloud(const ScanNode& scan, double maxrange=-1., bool lazy_eval = false, bool discretize = false);
 
     /**
+     * Works just like a wrapper with endpoint_occupied set to true.
+     */
+    virtual void insertPointCloudRays(const Pointcloud& scan, const point3d& sensor_origin, double maxrange = -1., bool lazy_eval = false);
+
+    /**
      * Integrate a Pointcloud (in global reference frame), parallelized with OpenMP.
      * This function simply inserts all rays of the point clouds as batch operation.
      * Discretization effects can lead to the deletion of occupied space, it is
@@ -140,10 +145,11 @@ namespace octomap {
      * @param scan Pointcloud (measurement endpoints), in global reference frame
      * @param sensor_origin measurement origin in global reference frame
      * @param maxrange maximum range for how long individual beams are inserted (default -1: complete beam)
+     * @param endpoint_occupied specifies it the endpoints should be updated as occupied or not
      * @param lazy_eval whether update of inner nodes is omitted after the update (default: false).
      *   This speeds up the insertion, but you need to call updateInnerOccupancy() when done.
      */
-     virtual void insertPointCloudRays(const Pointcloud& scan, const point3d& sensor_origin, double maxrange = -1., bool lazy_eval = false);
+     virtual void insertPointCloudRays(const Pointcloud& scan, const point3d& sensor_origin, double maxrange = -1., bool endpoint_occupied = true, bool lazy_eval = false);
 
      /**
       * Set log_odds value of voxel to log_odds_value. This only works if key is at the lowest

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -111,9 +111,12 @@ namespace octomap {
     insertPointCloud(transformed_scan, transformed_sensor_origin, maxrange, lazy_eval, discretize);
   }
 
+  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double maxrange, bool lazy_eval) {
+    insertPointCloudRays(pc, origin, maxrange, true, lazy_eval);
+  }
 
   template <class NODE>
-  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double /* maxrange */, bool lazy_eval) {
+  void OccupancyOcTreeBase<NODE>::insertPointCloudRays(const Pointcloud& pc, const point3d& origin, double /* maxrange */, bool endpoint_occupied, bool lazy_eval) {
     if (pc.size() < 1)
       return;
 
@@ -137,7 +140,7 @@ namespace octomap {
           for(KeyRay::iterator it=keyray->begin(); it != keyray->end(); it++) {
             updateNode(*it, false, lazy_eval); // insert freespace measurement
           }
-          updateNode(p, true, lazy_eval); // update endpoint to be occupied
+          updateNode(p, endpoint_occupied, lazy_eval); // update endpoint to be occupied
         }
       }
 

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -140,7 +140,7 @@ namespace octomap {
           for(KeyRay::iterator it=keyray->begin(); it != keyray->end(); it++) {
             updateNode(*it, false, lazy_eval); // insert freespace measurement
           }
-          updateNode(p, endpoint_occupied, lazy_eval); // update endpoint to be occupied
+          updateNode(p, endpoint_occupied, lazy_eval); // update endpoint
         }
       }
 


### PR DESCRIPTION
A parameter to specify whether the endpoint of a ray should be marked as occupied or not was added. This can be used when there is an obstacle farher than the range sensor measuring limit. The measurememnt can be then used to update the free cells while omitting the need to update some point as occupied.