### PR TITLE
octovis: Implement volume selection features

### DIFF
--- a/octovis/CMakeLists_src.txt
+++ b/octovis/CMakeLists_src.txt
@@ -100,7 +100,12 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR})
 
 # Library target 
 add_library(octovis-static STATIC ${viewerlib_SRCS})
-target_link_libraries(octovis-static)
+target_link_libraries(octovis-static
+  ${OPENGL_gl_LIBRARY} 
+  ${OPENGL_glu_LIBRARY} 
+  ${OCTOMAP_LIBRARIES}
+  ${QGLViewer_LIBRARIES}
+)
 set_target_properties(octovis-static PROPERTIES OUTPUT_NAME octovis)
 
 add_library(octovis-shared SHARED ${viewerlib_SRCS})

--- a/octovis/CMakeLists_src.txt
+++ b/octovis/CMakeLists_src.txt
@@ -100,12 +100,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR})
 
 # Library target 
 add_library(octovis-static STATIC ${viewerlib_SRCS})
-target_link_libraries(octovis-static
-  ${OPENGL_gl_LIBRARY} 
-  ${OPENGL_glu_LIBRARY} 
-  ${OCTOMAP_LIBRARIES}
-  ${QGLViewer_LIBRARIES}
-)
+target_link_libraries(octovis-static)
 set_target_properties(octovis-static PROPERTIES OUTPUT_NAME octovis)
 
 add_library(octovis-shared SHARED ${viewerlib_SRCS})

--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -29,7 +29,7 @@
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets>
 #else  // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include <QtGui/QMainWindow>
+#include <QtGui>
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QFileDialog>
 #include <QMessageBox>

--- a/octovis/include/octovis/ViewerGui.h
+++ b/octovis/include/octovis/ViewerGui.h
@@ -27,7 +27,7 @@
 
 #include <qglobal.h>
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include <QtWidgets/QMainWindow>
+#include <QtWidgets>
 #else  // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtGui/QMainWindow>
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
@@ -113,6 +113,7 @@ namespace octomap {
     void on_actionHideBackground_toggled(bool checked);
     void on_actionAlternateRendering_toggled(bool checked);
     void on_actionClear_triggered();
+    void voxelSelected(const QMouseEvent* e);
 
     void on_action_bg_black_triggered();
     void on_action_bg_white_triggered();
@@ -213,6 +214,7 @@ namespace octomap {
     unsigned int m_max_tree_depth;
     unsigned int m_laserType; // SICK or Hokuyo /URG
     bool m_cameraStored;
+    QLabel* m_nodeSelected;
     QLabel* m_mapSizeStatus;
     QLabel* m_mapMemoryStatus;
 

--- a/octovis/include/octovis/ViewerWidget.h
+++ b/octovis/include/octovis/ViewerWidget.h
@@ -86,6 +86,7 @@ private slots:
 signals:
    void cameraPathStopped(int id);
    void cameraPathFrameChanged(int id, int current_camera_frame);
+   void select(const QMouseEvent* e);
 
  protected:
 

--- a/octovis/src/OcTreeDrawer.cpp
+++ b/octovis/src/OcTreeDrawer.cpp
@@ -100,14 +100,14 @@ namespace octomap {
 
       glEnableClientState(GL_VERTEX_ARRAY);
 
+        if (m_drawSelection) // Drawing voxels in descending alpha-channel magnitude avoids (most) artifacts
+          drawSelection();
         if (m_drawOccupied)
           drawOccupiedVoxels();
         if (m_drawFree)
           drawFreeVoxels();
         if (m_drawOcTreeGrid)
           drawOctreeGrid();
-        if (m_drawSelection)
-          drawSelection();
 
         if (m_displayAxes) {
           drawAxes();
@@ -239,6 +239,10 @@ namespace octomap {
 
   void OcTreeDrawer::setOcTreeSelection(const std::list<octomap::OcTreeVolume>& selectedVoxels){
     m_update = true;
+
+    // init selectedVoxels GLarray
+    initGLArrays(selectedVoxels.size(), m_selectionSize, &m_selectionArray, NULL);
+
     generateCubes(selectedVoxels, &m_selectionArray, m_selectionSize, this->origin);
   }
 
@@ -739,7 +743,7 @@ namespace octomap {
 
   void OcTreeDrawer::drawSelection() const {
     if (m_selectionSize != 0) {
-      glColor4f(1.0, 0.0, 0.0, 0.5);
+      glColor4f(1.0, 0.0, 0.0, 1.0);
       drawCubes(m_selectionArray, m_selectionSize);
     }
   }

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -1085,6 +1085,7 @@ void ViewerGui::voxelSelected(const QMouseEvent* e){
   const point3d direction3d{(float)direction.x,(float)direction.y,(float)direction.z};
   point3d end3d; // voxel coords hit by ray
   QString message = QString("--, --, -- m");
+  std::list<octomap::OcTreeVolume> selection;
 
   for (std::map<int, OcTreeRecord>::iterator it = m_octrees.begin(); it != m_octrees.end(); ++it)
   {
@@ -1106,7 +1107,11 @@ void ViewerGui::voxelSelected(const QMouseEvent* e){
     if (ray_hit)
     {
       message = QString("%L1, %L2, %L3 m").arg(end3d.x()).arg(end3d.y()).arg(end3d.z());
+      OcTreeVolume voxel = OcTreeVolume(end3d, tree->getResolution());
+      selection.push_back(voxel);
+      it->second.octree_drawer->setOcTreeSelection(selection);
     }
+    else it->second.octree_drawer->clearOcTreeSelection();
   }
   m_nodeSelected->setText(message);
   m_glwidget->update();
@@ -1205,21 +1210,11 @@ void ViewerGui::on_actionFree_toggled(bool enabled) {
 }
 
 void ViewerGui::on_actionSelected_toggled(bool enabled) {
-    // if(m_octreeDrawer) {
-    //   m_octreeDrawer->enableSelection(enabled);
-
-  //   // just for testing, you should set the selection somewhere else and only enable it here:
-  //   if (enabled){
-  //     std::list<OcTreeVolume> selection;
-  //     std::pair<octomath::Vector3, double> volume(octomath::Vector3(0.0, 0.0, 0.0), 0.2);
-  //     selection.push_back(volume);
-  //     m_octreeDrawer->setOcTreeSelection(selection);
-
-  //   } else{
-  //     m_octreeDrawer->clearOcTreeSelection();
-  //   }
-  //   m_glwidget->update();
-  // }
+  for (std::map<int, OcTreeRecord>::iterator it = m_octrees.begin();
+      it != m_octrees.end(); ++it) {
+        if(it->second.octree_drawer)
+          it->second.octree_drawer->enableSelection(enabled);
+  }
 }
 
 

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -126,9 +126,7 @@ ViewerGui::ViewerGui(const std::string& filename, QWidget *parent, unsigned int 
           m_glwidget, SLOT(setCamPose(const octomath::Pose6D&)));
 
   connect(ui.actionReset_view, SIGNAL(triggered()), m_glwidget, SLOT(resetView()));
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) // Requires Qt5
   connect(m_glwidget, SIGNAL(select(const QMouseEvent*)), this, SLOT(voxelSelected(const QMouseEvent*)));
-  #endif
 
   if (filename != ""){
     m_filename = filename;

--- a/octovis/src/ViewerGui.cpp
+++ b/octovis/src/ViewerGui.cpp
@@ -480,6 +480,8 @@ void ViewerGui::setOcTreeUISwitches() {
   ui.actionConvert_ml_tree->setEnabled(true);
   ui.actionReload_Octree->setEnabled(true);
   ui.actionSettings->setEnabled(false);
+  ui.actionSelected->setChecked(true);
+  ui.actionSelected->setEnabled(true);
 }
 
 void ViewerGui::openTree(){
@@ -1203,7 +1205,7 @@ void ViewerGui::on_actionFree_toggled(bool enabled) {
 }
 
 void ViewerGui::on_actionSelected_toggled(bool enabled) {
-  // if(m_octreeDrawer) {
+    // if(m_octreeDrawer) {
     //   m_octreeDrawer->enableSelection(enabled);
 
   //   // just for testing, you should set the selection somewhere else and only enable it here:


### PR DESCRIPTION
This PR closes the following issues:
#337 : by commits 92e39d7 and dd885fd
#338 : by commits: be87f58 and 9c73561 

The volume selection feature (selection is triggered with Shift+LClick in the viewer) adds the following UI changes:
- New panel in the octovis status bar showing the center coordinates of the last selected voxel ("--,--,--" when selecting empty space).
- Highlighting of the selected volume in 255red with alpha=1 (alpha is usually 0.8 in occupied volumes, so it is visually recognisable even if the occupied volume has the same color as the selected volume).

The changes can be seen in the below before/after figures.

**Before:**
![before](https://user-images.githubusercontent.com/22547158/117542939-f3272800-b01a-11eb-96eb-e321e9418f86.png)

**After (with a voxel selected):**
![after](https://user-images.githubusercontent.com/22547158/117542938-f28e9180-b01a-11eb-95b4-4fa88e6c473c.png)

Let me know if you'd like to separate the PR into multiple ones covering singular issues or anything else I can do to support the merging process!