### PR TITLE
Remove unused ament_cmake dependency.

### DIFF
--- a/dynamicEDT3D/package.xml
+++ b/dynamicEDT3D/package.xml
@@ -15,7 +15,6 @@
 
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
-  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 
   <buildtool_depend>cmake</buildtool_depend>
   <export>

--- a/octomap/package.xml
+++ b/octomap/package.xml
@@ -15,7 +15,6 @@
 
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
-  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 
   <buildtool_depend>cmake</buildtool_depend>
   <export>

--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -15,13 +15,12 @@
 
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
-  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 
   <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>
   </export>
-      
+
   <build_depend>octomap</build_depend>
 
   <!-- Qt5 -->


### PR DESCRIPTION
REP-136 recommends that third-party (non-ROS) packages add a runtime
dependency on catkin so that the setup scripts provided by the catkin
package which set up a ROS environment are installed along with that
package. In ROS 2, those scripts are provided by the ros_workspace
package and bloom transparently injects a dependency on ros_workspace
into every released package.

It would be possible to use ament_cmake (or more likely the individual
ament_cmake_core package to optionally provide the package.xml and
ament resource index registration but since what you have is working
fine I think just removing the unecessary dependency is a good next
step. As mentioned in
https://github.com/flexible-collision-library/fcl/pull/536#issuecomment-845533649
we haven't produced a definitive recommendation for third party packages
in ROS 2 but I've added it to a meeting agenda and we'll document the
conclusions of that discussion and share them as well.

Thanks @wxmerkt for prompting this in https://github.com/flexible-collision-library/fcl/pull/536#issuecomment-845489925