### PR TITLE
make setBBXMin/Max parameters const

### DIFF
--- a/octomap/include/octomap/OccupancyOcTreeBase.h
+++ b/octomap/include/octomap/OccupancyOcTreeBase.h
@@ -334,9 +334,9 @@ namespace octomap {
     void useBBXLimit(bool enable) { use_bbx_limit = enable; }
     bool bbxSet() const { return use_bbx_limit; }
     /// sets the minimum for a query bounding box to use
-    void setBBXMin (point3d& min);
+    void setBBXMin (const point3d& min);
     /// sets the maximum for a query bounding box to use
-    void setBBXMax (point3d& max);
+    void setBBXMax (const point3d& max);
     /// @return the currently set minimum for bounding box queries, if set
     point3d getBBXMin () const { return bbx_min; }
     /// @return the currently set maximum for bounding box queries, if set

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -882,7 +882,7 @@ namespace octomap {
   }
 
   template <class NODE>
-  void OccupancyOcTreeBase<NODE>::setBBXMin (point3d& min) {
+  void OccupancyOcTreeBase<NODE>::setBBXMin (const point3d& min) {
     bbx_min = min;
     if (!this->coordToKeyChecked(bbx_min, bbx_min_key)) {
       OCTOMAP_ERROR("ERROR while generating bbx min key.\n");
@@ -890,7 +890,7 @@ namespace octomap {
   }
 
   template <class NODE>
-  void OccupancyOcTreeBase<NODE>::setBBXMax (point3d& max) {
+  void OccupancyOcTreeBase<NODE>::setBBXMax (const point3d& max) {
     bbx_max = max;
     if (!this->coordToKeyChecked(bbx_max, bbx_max_key)) {
       OCTOMAP_ERROR("ERROR while generating bbx max key.\n");


### PR DESCRIPTION
otherwise passing temporaries does not work.
Found it while writing code for MoveIt's octomap plugin.