### PR TITLE
Bug fix to update freespace when bbx is set.

### DIFF
--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -235,7 +235,7 @@ namespace octomap {
           }
         } // end if in BBX and not maxrange
 
-        // truncate the end point to the max range if the max range is exceededs
+        // truncate the end point to the max range if the max range is exceeded
         point3d new_end = p;
         if ((max_range >= 0.0) && ((p - origin).norm() > maxrange)) {
           const point3d direction = (p - origin).normalized();

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -237,7 +237,7 @@ namespace octomap {
 
         // truncate the end point to the max range if the max range is exceeded
         point3d new_end = p;
-        if ((max_range >= 0.0) && ((p - origin).norm() > maxrange)) {
+        if ((maxrange >= 0.0) && ((p - origin).norm() > maxrange)) {
           const point3d direction = (p - origin).normalized();
           new_end = origin + direction * (float) maxrange;
         }

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -243,7 +243,7 @@ namespace octomap {
         }
 
         // update freespace, break as soon as bbx limit is reached
-        if (this->computeRayKeys(origin, p, *keyray)){
+        if (this->computeRayKeys(origin, new_end, *keyray)){
           for(KeyRay::reverse_iterator rit=keyray->rbegin(); rit != keyray->rend(); rit++) {
             if (inBBX(*rit)) {
 #ifdef _OPENMP

--- a/octomap/include/octomap/OccupancyOcTreeBase.hxx
+++ b/octomap/include/octomap/OccupancyOcTreeBase.hxx
@@ -244,13 +244,13 @@ namespace octomap {
 
         // update freespace, break as soon as bbx limit is reached
         if (this->computeRayKeys(origin, new_end, *keyray)){
-          for(KeyRay::reverse_iterator rit=keyray->rbegin(); rit != keyray->rend(); rit++) {
-            if (inBBX(*rit)) {
+          for(KeyRay::iterator it=keyray->begin(); it != keyray->end(); it++) {
+            if (inBBX(*it)) {
 #ifdef _OPENMP
               #pragma omp critical (free_insert)
 #endif
               {
-                free_cells.insert(*rit);
+                free_cells.insert(*it);
               }
             }
             else break;

--- a/octomap/src/testing/CMakeLists.txt
+++ b/octomap/src/testing/CMakeLists.txt
@@ -26,6 +26,9 @@ if(BUILD_TESTING)
   ADD_EXECUTABLE(test_pruning test_pruning.cpp)
   TARGET_LINK_LIBRARIES(test_pruning octomap octomath)
 
+  ADD_EXECUTABLE(test_bbx test_bbx.cpp)
+  TARGET_LINK_LIBRARIES(test_bbx octomap)
+
 
   # CTest tests below
 
@@ -46,4 +49,5 @@ if(BUILD_TESTING)
   ADD_TEST (NAME test_iterators     COMMAND test_iterators ${PROJECT_SOURCE_DIR}/share/data/geb079.bt)
   ADD_TEST (NAME test_mapcollection COMMAND test_mapcollection ${PROJECT_SOURCE_DIR}/share/data/mapcoll.txt)
   ADD_TEST (NAME test_color_tree    COMMAND test_color_tree)
+  ADD_TEST (NAME test_bbx           COMMAND test_bbx)
 endif()

--- a/octomap/src/testing/test_bbx.cpp
+++ b/octomap/src/testing/test_bbx.cpp
@@ -18,6 +18,7 @@ int main(int /*argc*/, char** /*argv*/) {
 
   // Set up the point cloud. Offset the origin by half resolution to use the
   // center of a voxel.
+  Pointcloud cloud;
   const point3d origin(resolution / 2.f, 5.f + resolution / 2.f, resolution / 2.f);
   const float maxrange = 8.f;
   // The first point is inside the bounding box and max range.

--- a/octomap/src/testing/test_bbx.cpp
+++ b/octomap/src/testing/test_bbx.cpp
@@ -39,23 +39,24 @@ int main(int /*argc*/, char** /*argv*/) {
   // Searching in the x-direction from the origin finds the first point.
   bool ray_cast_ret = tree.castRay(origin, point3d(1.f, 0.f, 0.f), end_point);
   EXPECT_TRUE(ray_cast_ret);
-  EXPECT_FLOAT_EQ(end_point.x(), point0.x());
-  EXPECT_FLOAT_EQ(end_point.y(), point0.y());
-  EXPECT_FLOAT_EQ(end_point.z(), point0.z());
+  const float eps = 1e-3;
+  EXPECT_NEAR(end_point.x(), point0.x(), eps);
+  EXPECT_NEAR(end_point.y(), point0.y(), eps);
+  EXPECT_NEAR(end_point.z(), point0.z(), eps);
 
   // Searching in the y-direction from the origin terminates just outside the
   // bounding box.
   ray_cast_ret = tree.castRay(origin, point3d(0.f, 1.f, 0.f), end_point);
   EXPECT_FALSE(ray_cast_ret);
-  EXPECT_FLOAT_EQ(end_point.x(), point1.x());
-  EXPECT_FLOAT_EQ(end_point.y(), bbx_limit + resolution);
-  EXPECT_FLOAT_EQ(end_point.z(), point1.z());
+  EXPECT_NEAR(end_point.x(), point1.x(), eps);
+  EXPECT_NEAR(end_point.y(), bbx_limit + resolution, eps);
+  EXPECT_NEAR(end_point.z(), point1.z(), eps);
 
   // Searching in the z-direction from the origin terminates at the max range.
   ray_cast_ret = tree.castRay(origin, point3d(0.f, 0.f, 1.f), end_point);
   EXPECT_FALSE(ray_cast_ret);
-  EXPECT_FLOAT_EQ(end_point.x(), point2.x());
-  EXPECT_FLOAT_EQ(end_point.y(), point2.y());
-  EXPECT_FLOAT_EQ(end_point.z(), origin.z() + maxrange);
+  EXPECT_NEAR(end_point.x(), point2.x(), eps);
+  EXPECT_NEAR(end_point.y(), point2.y(), eps);
+  EXPECT_NEAR(end_point.z(), origin.z() + maxrange, eps);
   return 0;
 }

--- a/octomap/src/testing/test_bbx.cpp
+++ b/octomap/src/testing/test_bbx.cpp
@@ -1,0 +1,60 @@
+
+#include <octomap/octomap.h>
+#include "testing.h"
+
+using namespace octomap;
+
+int main(int /*argc*/, char** /*argv*/) {
+  const float resolution = 0.2f;
+  OcTree tree(resolution);
+
+  // Set up the bounding box.
+  const float bbx_limit = 10.1f;
+  point3d bbx_min(-bbx_limit, -bbx_limit, -bbx_limit);
+  point3d bbx_max(bbx_limit, bbx_limit, bbx_limit);
+  tree.setBBXMin(bbx_min);
+  tree.setBBXMax(bbx_max);
+  tree.useBBXLimit(true);
+
+  // Set up the point cloud. Offset the origin by half resolution to use the
+  // center of a voxel.
+  const point3d origin(resolution / 2.f, 5.f + resolution / 2.f, resolution / 2.f);
+  const float maxrange = 8.f;
+  // The first point is inside the bounding box and max range.
+  const point3d point0 = origin + point3d(5.f, 0.f, 0.f);
+  cloud.push_back(point0);
+  // The second point is outside the bounding box but within max range.
+  const point3d point1 = origin + point3d(0.f, 7.f, 0.f);
+  cloud.push_back(point1);
+  // The third point is inside the bounding box but outside max range.
+  const point3d point2 = origin + point3d(0.f, 0.f, 9.f);
+  cloud.push_back(point2);
+  tree.insertPointCloud(cloud, origin, maxrange);
+
+  // Check the point cloud insertion using ray casting.
+  tree.setOccupancyThres(0.5f);
+  point3d end_point;
+
+  // Searching in the x-direction from the origin finds the first point.
+  bool ray_cast_ret = tree.castRay(origin, point3d(1.f, 0.f, 0.f), end_point);
+  EXPECT_TRUE(ray_cast_ret);
+  EXPECT_FLOAT_EQ(end_point.x(), point0.x());
+  EXPECT_FLOAT_EQ(end_point.y(), point0.y());
+  EXPECT_FLOAT_EQ(end_point.z(), point0.z());
+
+  // Searching in the y-direction from the origin terminates just outside the
+  // bounding box.
+  ray_cast_ret = tree.castRay(origin, point3d(0.f, 1.f, 0.f), end_point);
+  EXPECT_FALSE(ray_cast_ret);
+  EXPECT_FLOAT_EQ(end_point.x(), point1.x());
+  EXPECT_FLOAT_EQ(end_point.y(), bbx_limit + resolution);
+  EXPECT_FLOAT_EQ(end_point.z(), point1.z());
+
+  // Searching in the z-direction from the origin terminates at the max range.
+  ray_cast_ret = tree.castRay(origin, point3d(0.f, 0.f, 1.f), end_point);
+  EXPECT_FALSE(ray_cast_ret);
+  EXPECT_FLOAT_EQ(end_point.x(), point2.x());
+  EXPECT_FLOAT_EQ(end_point.y(), point2.y());
+  EXPECT_FLOAT_EQ(end_point.z(), origin.z() + maxrange);
+  return 0;
+}

--- a/octomap/src/testing/testing.h
+++ b/octomap/src/testing/testing.h
@@ -14,18 +14,18 @@
     } }
 
 #define EXPECT_EQ(a,b) {                                                \
-    if (!(a == b)) { std::cerr << "test failed: " <<a<<"!="<<b<< " in " \
+    if (!((a) == (b))) { std::cerr << "test failed: " <<a<<"!="<<b<< " in " \
                       << __FILE__ << ", line " <<__LINE__ << std::endl; \
       exit(1);                                                          \
     } }
 
 #define EXPECT_FLOAT_EQ(a,b) {                                          \
-    if (!(fabs(a-b) <= 1e-5)) { fprintf(stderr, "test failed: %f != %f in %s, line %d\n", a, b, __FILE__, __LINE__); \
+    if (!(fabs((a) - (b)) <= 1e-5)) { fprintf(stderr, "test failed: %f != %f in %s, line %d\n", a, b, __FILE__, __LINE__); \
       exit(1);                                                         \
     } }
 
 #define EXPECT_NEAR(a,b,prec) {                                         \
-    if (!(fabs(a-b) <= prec)) { fprintf(stderr, "test failed: |%f - %f| > %f in %s, line %d\n", a, b, prec, __FILE__, __LINE__); \
+    if (!(fabs((a) - (b)) <= prec)) { fprintf(stderr, "test failed: |%f - %f| > %f in %s, line %d\n", a, b, prec, __FILE__, __LINE__); \
       exit(1);                                                         \
     } }
 


### PR DESCRIPTION
This pull request addresses #358. If the bounding box is set and the scan point is within the bounding box and within the max range (if set), then the cell containing the the scan point is added to occupied cells. Now, even if the scan point is outside the bounding box or beyond the max range, cells will be added to the free cells set. The end point is truncated to stop at the max range if the original scan point is beyond max range. Then, we iterate through the key ray and add cells to the free_cells list, breaking when we leave the bounding box.