### PR TITLE
Also set lowercase octomap_* variables in CMake config

### DIFF
--- a/octomap/octomap-config.cmake.in
+++ b/octomap/octomap-config.cmake.in
@@ -39,4 +39,15 @@ set(OCTOMAP_LIBRARIES
   "@PACKAGE_OCTOMAP_LIB_DIR@/@OCTOMATH_LIBRARY@"
 )
 
+# Additionally set the variables using a lower-case project name.
+# This fixes discovery for downstream packages that search for lower-case octomap, which has been common in downstream code:
+set(octomap_MAJOR_VERSION "${OCTOMAP_MAJOR_VERSION}")
+set(octomap_MINOR_VERSION "${OCTOMAP_MINOR_VERSION}")
+set(octomap_PATCH_VERSION "${OCTOMAP_PATCH_VERSION}")
+set(octomap_VERSION "${OCTOMAP_VERSION}")
+set(octomap_INCLUDE_DIRS "${OCTOMAP_INCLUDE_DIRS}")
+set(octomap_LIBRARY_DIRS "${OCTOMAP_LIBRARY_DIRS}")
+set(octomap_LIBRARIES "${OCTOMAP_LIBRARIES}")
+
+
 @OCTOMAP_INCLUDE_TARGETS@


### PR DESCRIPTION
Relates to https://github.com/OctoMap/octomap/issues/138

We have seen issues where OctoMap did not get configured properly due to common use of `find_package(octomap REQUIRED)` in downstream packages (i.e. lower-case octomap). This issue has become more common on ROS2 and previously was circumvented by a patch to change the LIBDIR. Defining both variables grandfathers in downstream users (including using ament-auto-configure) by also providing the required configuration variables with a lower-case as in the project name.