### PR TITLE
replace deprecated std::iterator by defining required types

### DIFF
--- a/octomap/include/octomap/OcTreeIterator.hxx
+++ b/octomap/include/octomap/OcTreeIterator.hxx
@@ -39,8 +39,15 @@
      * const with respect to the tree. This file is included within
      * OcTreeBaseImpl.h, you should probably not include this directly.
      */
-    class iterator_base : public std::iterator<std::forward_iterator_tag, NodeType>{
+    template<class NodeType>
+    class iterator_base{
     public:
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = NodeType;
+      using difference_type = NodeType;
+      using pointer = NodeType*;
+      using reference = NodeType&;
+
       struct StackElement;
       /// Default ctor, only used for the end-iterator
       iterator_base() : tree(NULL), maxDepth(0){}
@@ -204,16 +211,16 @@
      * }
      * @endcode
      */
-    class tree_iterator : public iterator_base {
+    class tree_iterator : public iterator_base<NodeType> {
     public:
-      tree_iterator() : iterator_base(){}
+      tree_iterator() : iterator_base<NodeType>(){}
       /**
        * Constructor of the iterator.
        *
        * @param ptree OcTreeBaseImpl on which the iterator is used on
        * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
        */
-      tree_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, uint8_t depth=0) : iterator_base(ptree, depth) {};
+      tree_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, uint8_t depth=0) : iterator_base<NodeType>(ptree, depth) {};
 
       /// postfix increment operator of iterator (it++)
       tree_iterator operator++(int){
@@ -260,9 +267,9 @@
      * @endcode
      *
      */
-    class leaf_iterator : public iterator_base {
+    class leaf_iterator : public iterator_base<NodeType> {
       public:
-          leaf_iterator() : iterator_base(){}
+          leaf_iterator() : iterator_base<NodeType>(){}
 
           /**
           * Constructor of the iterator.
@@ -270,7 +277,7 @@
           * @param ptree OcTreeBaseImpl on which the iterator is used on
           * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
           */
-          leaf_iterator(OcTreeBaseImpl<NodeType, INTERFACE> const* ptree, uint8_t depth=0) : iterator_base(ptree, depth) {
+          leaf_iterator(OcTreeBaseImpl<NodeType, INTERFACE> const* ptree, uint8_t depth=0) : iterator_base<NodeType>(ptree, depth) {
             // tree could be empty (= no stack)
             if (this->stack.size() > 0){
               // skip forward to next valid leaf node:
@@ -280,7 +287,7 @@
             }
           }
 
-          leaf_iterator(const leaf_iterator& other) : iterator_base(other) {};
+          leaf_iterator(const leaf_iterator& other) : iterator_base<NodeType>(other) {};
 
           /// postfix increment operator of iterator (it++)
           leaf_iterator operator++(int){
@@ -332,9 +339,9 @@
      * }
      * @endcode
      */
-    class leaf_bbx_iterator : public iterator_base {
+    class leaf_bbx_iterator : public iterator_base<NodeType> {
     public:
-      leaf_bbx_iterator() : iterator_base() {};
+      leaf_bbx_iterator() : iterator_base<NodeType>() {};
       /**
       * Constructor of the iterator. The bounding box corners min and max are
       * converted into an OcTreeKey first.
@@ -351,7 +358,7 @@
       * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
       */
       leaf_bbx_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, const point3d& min, const point3d& max, uint8_t depth=0)
-        : iterator_base(ptree, depth)
+        : iterator_base<NodeType>(ptree, depth)
       {
         if (this->stack.size() > 0){
           assert(ptree);
@@ -379,7 +386,7 @@
       * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
       */
       leaf_bbx_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, const OcTreeKey& min, const OcTreeKey& max, uint8_t depth=0)
-        : iterator_base(ptree, depth), minKey(min), maxKey(max)
+        : iterator_base<NodeType>(ptree, depth), minKey(min), maxKey(max)
       {
         // tree could be empty (= no stack)
         if (this->stack.size() > 0){
@@ -389,7 +396,7 @@
         }
       }
 
-      leaf_bbx_iterator(const leaf_bbx_iterator& other) : iterator_base(other) {
+      leaf_bbx_iterator(const leaf_bbx_iterator& other) : iterator_base<NodeType>(other) {
         minKey = other.minKey;
         maxKey = other.maxKey;
       }
@@ -430,10 +437,10 @@
     protected:
 
       void singleIncrement(){
-        typename iterator_base::StackElement top = this->stack.top();
+        typename iterator_base<NodeType>::StackElement top = this->stack.top();
         this->stack.pop();
 
-        typename iterator_base::StackElement s;
+        typename iterator_base<NodeType>::StackElement s;
         s.depth = top.depth +1;
         key_type center_offset_key = this->tree->tree_max_val >> s.depth;
         // push on stack in reverse order


### PR DESCRIPTION
Solves #372 

Based on reading following helpful source: https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/

With this build error resolved, octomap is cxx17 compat.