### PR TITLE
fix test dependencies

### DIFF
--- a/octomap/src/testing/CMakeLists.txt
+++ b/octomap/src/testing/CMakeLists.txt
@@ -50,4 +50,6 @@ if(BUILD_TESTING)
   ADD_TEST (NAME test_mapcollection COMMAND test_mapcollection ${PROJECT_SOURCE_DIR}/share/data/mapcoll.txt)
   ADD_TEST (NAME test_color_tree    COMMAND test_color_tree)
   ADD_TEST (NAME test_bbx           COMMAND test_bbx)
+
+  SET_TESTS_PROPERTIES (ReadGraph PROPERTIES DEPENDS InsertScan)
 endif()


### PR DESCRIPTION
Hi,

Running tests with `CTEST_PARALLEL_LEVEL` > 1, I get the following error:
```
3/14 Test  #5: ReadGraph ........................***Failed    0.00 sec
ERROR: Filestream to test.graph not open, nothing read.
test failed (EXPECT_TRUE) in octomap/src/testing/unit_tests.cpp, line 154
```

So I guess we need to explain to CMake that `ReadGraph` must wait for `InsertScan`, ref:
https://github.com/OctoMap/octomap/blob/b7118e096abb223fe3ce2af70e6f8c751989fe1d/octomap/src/testing/unit_tests.cpp#L147