### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ To compile the complete package, run:
 Binaries and libs will end up in the directories `bin` and `lib` of the
 top-level directory where you started the build.
 
+Alternatively, you can build and install octomap using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install octomap
+
+The octomap port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 See [octomap README](octomap/README.md) and [octovis README](octovis/README.md) for further
 details and hints on compiling, especially under Windows.


### PR DESCRIPTION
`octomap` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `octomap` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `octomap`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/octomap/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊