### PR TITLE
ScanGraph.h - fix c++20 compilation error

### DIFF
--- a/octomap/include/octomap/ScanGraph.h
+++ b/octomap/include/octomap/ScanGraph.h
@@ -60,7 +60,7 @@ namespace octomap {
 
     ~ScanNode();
 
-    bool operator == (const ScanNode& other) {
+    bool operator == (const ScanNode& other) const {
       return (id == other.id);
     }
 
@@ -87,7 +87,7 @@ namespace octomap {
       : first(_first), second(_second), constraint(_constraint), weight(1.0) { }
     ScanEdge() {}
 
-    bool operator == (const ScanEdge& other) {
+    bool operator == (const ScanEdge& other) const {
       return ( (*first == *(other.first) ) && ( *second == *(other.second) ) );
     }
 


### PR DESCRIPTION
This fixes the following error on latest msvc compiler:

error C2666: 'octomap::ScanNode::operator ==': overloaded functions have similar conversions
message : could be 'bool octomap::ScanNode::operator ==(const octomap::ScanNode &)'
message : or 'bool octomap::ScanNode::operator ==(const octomap::ScanNode &)' [synthesized expression 'y == x']
message : while trying to match the argument list '(octomap::ScanNode, octomap::ScanNode)'