### PR TITLE
Declare missing octovis dependency on opengl

### DIFF
--- a/octovis/package.xml
+++ b/octovis/package.xml
@@ -22,6 +22,7 @@
   </export>
 
   <build_depend>octomap</build_depend>
+  <build_depend>opengl</build_depend>
 
   <!-- Qt5 -->
   <build_depend>libqglviewer-dev-qt5</build_depend>
@@ -34,6 +35,7 @@
   <build_depend>libqt4-opengl-dev</build_depend> -->
 
   <exec_depend>octomap</exec_depend>
+  <exec_depend>opengl</exec_depend>
 
   <!-- Qt5 -->
   <exec_depend>libqglviewer2-qt5</exec_depend>


### PR DESCRIPTION
It appears that libGLU is an indirect dependency on Ubuntu, but not on RHEL/Fedora. Better to be explicit anyway.

Here's the rosdep key: https://github.com/ros/rosdistro/blob/f4e07369c9790cd890a4cb34c001c94e8d4aad69/rosdep/base.yaml#L6943C1-L6958

Here's where openGL is found: https://github.com/OctoMap/octomap/blob/312f6b072c379489e2c00307bb35f8e7a851bed7/octovis/CMakeLists.txt#L71

Here's where both libGL and libGLU are referenced: https://github.com/OctoMap/octomap/blob/312f6b072c379489e2c00307bb35f8e7a851bed7/octovis/CMakeLists_src.txt#L104-L105

This is why `octovis` is [blocked](https://github.com/ros2/ros_buildfarm_config/blob/70e06f3ba7670bc030148893c40405b0092347d6/rolling/release-rhel-build.yaml#L33) on the ROS 2 buildfarm for RHEL.