### PR TITLE
always enable C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,7 @@ option(BUILD_OCTOVIS_SUBPROJECT "Build targets from subproject octovis" ON)
 option(BUILD_DYNAMICETD3D_SUBPROJECT  "Build targets from subproject dynamicEDT3D" ON)
 option(OCTOVIS_QT5 "Link Octovis against Qt5?" ON)
 
-if(OCTOVIS_QT5)
-	# Compiling against QT5 requires C++11.
-	set(CMAKE_CXX_STANDARD 11)
-endif(OCTOVIS_QT5)
+set(CMAKE_CXX_STANDARD 11)
 
 ADD_SUBDIRECTORY( octomap )
 


### PR DESCRIPTION
I met compilation error octomap/1.10.0 on gcc 5.4.

<details>
<summary>compilation error</summary>

```
In file included from ./octomap/include/octomap/OcTreeBaseImpl.h:83:0,
                 from ./octomap/include/octomap/OccupancyOcTreeBase.h:44,
                 from ./octomap/include/octomap/OcTreeStamped.h:39,
                 from ./octomap/src/OcTreeStamped.cpp:34:
./octomap/include/octomap/OcTreeIterator.hxx:45:13: error: expected nested-name-specifier before ‘iterator_category’
       using iterator_category = std::forward_iterator_tag;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:46:13: error: expected nested-name-specifier before ‘value_type’
       using value_type = NodeType;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:47:13: error: expected nested-name-specifier before ‘difference_type’
       using difference_type = NodeType;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:48:13: error: expected nested-name-specifier before ‘pointer’
       using pointer = NodeType*;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:49:13: error: expected nested-name-specifier before ‘reference’
       using reference = NodeType&;
             ^
In file included from ./octomap/include/octomap/OcTreeBaseImpl.h:83:0,
                 from ./octomap/include/octomap/OccupancyOcTreeBase.h:44,
                 from ./octomap/include/octomap/OcTree.h:38,
                 from ./octomap/src/OcTree.cpp:34:
./octomap/include/octomap/OcTreeIterator.hxx:45:13: error: expected nested-name-specifier before ‘iterator_category’
       using iterator_category = std::forward_iterator_tag;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:46:13: error: expected nested-name-specifier before ‘value_type’
       using value_type = NodeType;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:47:13: error: expected nested-name-specifier before ‘difference_type’
       using difference_type = NodeType;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:48:13: error: expected nested-name-specifier before ‘pointer’
       using pointer = NodeType*;
             ^
./octomap/include/octomap/OcTreeIterator.hxx:49:13: error: expected nested-name-specifier before ‘reference’
       using reference = NodeType&;
             ^
```
</details>

It seems to be caused by using `type alias`.
`type alias` has been introduced C++11. [ref](https://en.cppreference.com/w/cpp/language/type_alias)

This PR ensures that C++11 is always used on CMakeLists.txt.

