### PR TITLE
Eliminate causes for AppleClang warnings

### DIFF
--- a/octomap/include/octomap/MapCollection.hxx
+++ b/octomap/include/octomap/MapCollection.hxx
@@ -127,13 +127,13 @@ namespace octomap {
   }
 
   template <class MAPNODE>
-  MAPNODE* MapCollection<MAPNODE>::addNode(const Pointcloud& cloud, point3d sensor_origin) {
+  MAPNODE* MapCollection<MAPNODE>::addNode(const Pointcloud&, point3d) {
     // TODO...
     return 0;
   }
 
   template <class MAPNODE>
-  bool MapCollection<MAPNODE>::removeNode(const MAPNODE* n) {
+  bool MapCollection<MAPNODE>::removeNode(const MAPNODE*) {
     // TODO...
     return false;
   }
@@ -252,8 +252,8 @@ namespace octomap {
 
   // TODO
   template <class MAPNODE>
-  void MapCollection<MAPNODE>::insertScan(const Pointcloud& scan, const octomap::point3d& sensor_origin,
-                                          double maxrange, bool pruning, bool lazy_eval) {
+  void MapCollection<MAPNODE>::insertScan(const Pointcloud&, const octomap::point3d&,
+                                          double, bool, bool) {
     fprintf(stderr, "ERROR: MapCollection::insertScan is not implemented yet.\n");
   }
 
@@ -267,7 +267,7 @@ namespace octomap {
         
   // TODO
   template <class MAPNODE>
-  std::vector<Pointcloud*> MapCollection<MAPNODE>::segment(const Pointcloud& scan) const {
+  std::vector<Pointcloud*> MapCollection<MAPNODE>::segment(const Pointcloud&) const {
     std::vector<Pointcloud*> result;
     fprintf(stderr, "ERROR: MapCollection::segment is not implemented yet.\n");
     return result;
@@ -275,7 +275,7 @@ namespace octomap {
 
   // TODO
   template <class MAPNODE>
-  MAPNODE* MapCollection<MAPNODE>::associate(const Pointcloud& scan) {
+  MAPNODE* MapCollection<MAPNODE>::associate(const Pointcloud&) {
     fprintf(stderr, "ERROR: MapCollection::associate is not implemented yet.\n");
     return 0;
   }

--- a/octomap/include/octomap/MapNode.hxx
+++ b/octomap/include/octomap/MapNode.hxx
@@ -44,7 +44,7 @@ namespace octomap {
   }
 
   template <class TREETYPE>
-  MapNode<TREETYPE>::MapNode(const Pointcloud& in_cloud, pose6d in_origin): node_map(0) {
+  MapNode<TREETYPE>::MapNode(const Pointcloud&, pose6d): node_map(0) {
   }
 
   template <class TREETYPE>
@@ -60,7 +60,7 @@ namespace octomap {
   }
 
   template <class TREETYPE>
-  void MapNode<TREETYPE>::updateMap(const Pointcloud& cloud, point3d sensor_origin) {
+  void MapNode<TREETYPE>::updateMap(const Pointcloud&, point3d) {
   }
 
   template <class TREETYPE>

--- a/octomap/include/octomap/OcTreeIterator.hxx
+++ b/octomap/include/octomap/OcTreeIterator.hxx
@@ -396,13 +396,6 @@
         }
       }
 
-      leaf_bbx_iterator(const leaf_bbx_iterator& other) : iterator_base<NodeType>(other) {
-        minKey = other.minKey;
-        maxKey = other.maxKey;
-      }
-
-
-
       /// postfix increment operator of iterator (it++)
       leaf_bbx_iterator operator++(int){
         leaf_bbx_iterator result = *this;


### PR DESCRIPTION
This cleans up a few inconsequential items that would otherwise trigger warnings (and errors if so promoted) in AppleClang.

- Unused parmeters
- Implicit deletion of copy assignment (by introduction of an unnecessary explicit copy constructor).