### PR TITLE
fix build with gcc16

### DIFF
--- a/octomap/include/octomap/OcTreeKey.h
+++ b/octomap/include/octomap/OcTreeKey.h
@@ -34,11 +34,6 @@
 #ifndef OCTOMAP_OCTREE_KEY_H
 #define OCTOMAP_OCTREE_KEY_H
 
-/* According to c++ standard including this header has no practical effect
- * but it can be used to determine the c++ standard library implementation.
- */
-#include <ciso646>
-
 #include <assert.h>
 
 /* Libc++ does not implement the TR1 namespace, all c++11 related functionality


### PR DESCRIPTION
Hi,

This follow #434 and fix:
```cpp
In file included from /build/source/octomap/include/octomap/OcTreeKey.h:40,
                 from /build/source/octomap/include/octomap/OcTreeBaseImpl.h:45,
                 from /build/source/octomap/include/octomap/OccupancyOcTreeBase.h:44,
                 from /build/source/octomap/include/octomap/OcTreeStamped.h:39,
                 from /build/source/octomap/src/OcTreeStamped.cpp:34:
/nix/store/mcd6qn183lsac6dy6xqm1ijhldixvfq2-gcc-16.1.0/include/c++/16.1.0/ciso646:49:6: error: #warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros" [-Werror=cpp]
   49 | #    warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros"
      |      ^~~~~~~
```

The inclusion of this header does not seem to be used, as octomap now build fine for me with gcc16.